### PR TITLE
Improve detail transitions

### DIFF
--- a/lib/screens/cars/car_details_screen.dart
+++ b/lib/screens/cars/car_details_screen.dart
@@ -66,31 +66,32 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
     super.initState();
 
     _animationController = AnimationController(
-      duration: const Duration(milliseconds: 1000),
+      duration: const Duration(milliseconds: 600),
       vsync: this,
     );
     _fabController = AnimationController(
-      duration: const Duration(milliseconds: 600),
+      duration: const Duration(milliseconds: 400),
       vsync: this,
     );
     _staggerController = AnimationController(
-      duration: const Duration(milliseconds: 1200),
+      duration: const Duration(milliseconds: 800),
       vsync: this,
     );
     _bookingPanelController = AnimationController(
-      duration: const Duration(milliseconds: 600),
+      duration: const Duration(milliseconds: 400),
       vsync: this,
     );
 
     _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
       CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
     );
-    _slideAnimation = Tween<Offset>(
-      begin: const Offset(0, 0.5),
-      end: Offset.zero,
-    ).animate(
-      CurvedAnimation(parent: _animationController, curve: Curves.easeOutBack),
-    );
+    _slideAnimation =
+        Tween<Offset>(begin: const Offset(0, 0.5), end: Offset.zero).animate(
+          CurvedAnimation(
+            parent: _animationController,
+            curve: Curves.easeOutBack,
+          ),
+        );
     _scaleAnimation = Tween<double>(begin: 0.9, end: 1.0).animate(
       CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
     );
@@ -369,22 +370,14 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
       }
 
       // Verify we have payment info before proceeding
-      log(
-        'Payment info retrieved successfully, proceeding to payment screen',
-      );
+      log('Payment info retrieved successfully, proceeding to payment screen');
 
       // Navigate to payment screen
       final result = await Navigator.of(context).push(
         PageRouteBuilder(
-          pageBuilder:
-              (context, animation, secondaryAnimation) =>
-                  CarPaymentScreen(paymentInfo: paymentInfo!),
-          transitionsBuilder: (
-            context,
-            animation,
-            secondaryAnimation,
-            child,
-          ) {
+          pageBuilder: (context, animation, secondaryAnimation) =>
+              CarPaymentScreen(paymentInfo: paymentInfo!),
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
             return SlideTransition(
               position: animation.drive(
                 Tween(
@@ -410,7 +403,7 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
           _isBooking = false;
         });
       }
-        } catch (e) {
+    } catch (e) {
       setState(() {
         _isBooking = false;
       });
@@ -741,10 +734,9 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
   }
 
   Widget _buildEnhancedImageGallery() {
-    final images =
-        _car!.images.isEmpty
-            ? [CarImage(id: 0, imageUrl: '', displayOrder: 0)]
-            : _car!.images;
+    final images = _car!.images.isEmpty
+        ? [CarImage(id: 0, imageUrl: '', displayOrder: 0)]
+        : _car!.images;
 
     return Stack(
       children: [
@@ -760,15 +752,14 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
             final image = images[index];
             return Container(
               decoration: BoxDecoration(
-                image:
-                    image.imageUrl.isNotEmpty
-                        ? DecorationImage(
-                          image: NetworkImage(image.imageUrl),
-                          fit: BoxFit.cover,
-                          onError:
-                              (error, stackTrace) => _buildImagePlaceholder(),
-                        )
-                        : null,
+                image: image.imageUrl.isNotEmpty
+                    ? DecorationImage(
+                        image: NetworkImage(image.imageUrl),
+                        fit: BoxFit.cover,
+                        onError: (error, stackTrace) =>
+                            _buildImagePlaceholder(),
+                      )
+                    : null,
               ),
               child: image.imageUrl.isEmpty ? _buildImagePlaceholder() : null,
             );
@@ -802,10 +793,9 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                       height: 8,
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(4),
-                        color:
-                            _currentImageIndex == index
-                                ? Colors.white
-                                : Colors.white.withOpacity(0.5),
+                        color: _currentImageIndex == index
+                            ? Colors.white
+                            : Colors.white.withOpacity(0.5),
                       ),
                     ),
                   ),
@@ -923,12 +913,11 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                     ),
                     Text(
                       _car!.displayPrice,
-                      style: Theme.of(
-                        context,
-                      ).textTheme.headlineMedium?.copyWith(
-                        color: colorScheme.primary,
-                        fontWeight: FontWeight.bold,
-                      ),
+                      style: Theme.of(context).textTheme.headlineMedium
+                          ?.copyWith(
+                            color: colorScheme.primary,
+                            fontWeight: FontWeight.bold,
+                          ),
                     ),
                   ],
                 ),
@@ -972,12 +961,11 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                     ),
                     Text(
                       _car!.displayPrice,
-                      style: Theme.of(
-                        context,
-                      ).textTheme.headlineSmall?.copyWith(
-                        color: colorScheme.primary,
-                        fontWeight: FontWeight.bold,
-                      ),
+                      style: Theme.of(context).textTheme.headlineSmall
+                          ?.copyWith(
+                            color: colorScheme.primary,
+                            fontWeight: FontWeight.bold,
+                          ),
                     ),
                   ],
                 ),
@@ -1304,12 +1292,11 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                       const SizedBox(height: 12),
                       Text(
                         'Interactive Map',
-                        style: Theme.of(
-                          context,
-                        ).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: colorScheme.onSurface.withOpacity(0.7),
-                        ),
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: colorScheme.onSurface.withOpacity(0.7),
+                            ),
                       ),
                       const SizedBox(height: 8),
                       Container(
@@ -1323,12 +1310,11 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                         ),
                         child: Text(
                           _car!.location,
-                          style: Theme.of(
-                            context,
-                          ).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.w600,
-                            color: colorScheme.primary,
-                          ),
+                          style: Theme.of(context).textTheme.titleMedium
+                              ?.copyWith(
+                                fontWeight: FontWeight.w600,
+                                color: colorScheme.primary,
+                              ),
                         ),
                       ),
                     ],
@@ -1465,11 +1451,10 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
             )
           else
             Column(
-              children:
-                  _reviews
-                      .take(3)
-                      .map((review) => _buildModernReviewItem(review))
-                      .toList(),
+              children: _reviews
+                  .take(3)
+                  .map((review) => _buildModernReviewItem(review))
+                  .toList(),
             ),
 
           if (_reviews.length > 3) ...[
@@ -1545,10 +1530,9 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                         index < _selectedRating
                             ? Icons.star_rounded
                             : Icons.star_border_rounded,
-                        color:
-                            index < _selectedRating
-                                ? Colors.amber
-                                : colorScheme.outline,
+                        color: index < _selectedRating
+                            ? Colors.amber
+                            : colorScheme.outline,
                         size: 32,
                       ),
                     ),
@@ -1643,21 +1627,19 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                             index < review.rating
                                 ? Icons.star_rounded
                                 : Icons.star_border_rounded,
-                            color:
-                                index < review.rating
-                                    ? Colors.amber
-                                    : colorScheme.outline,
+                            color: index < review.rating
+                                ? Colors.amber
+                                : colorScheme.outline,
                             size: 16,
                           );
                         }),
                         const SizedBox(width: 8),
                         Text(
                           '${review.createdAt.day}/${review.createdAt.month}/${review.createdAt.year}',
-                          style: Theme.of(
-                            context,
-                          ).textTheme.bodySmall?.copyWith(
-                            color: colorScheme.onSurface.withOpacity(0.6),
-                          ),
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(
+                                color: colorScheme.onSurface.withOpacity(0.6),
+                              ),
                         ),
                       ],
                     ),
@@ -1767,11 +1749,12 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                           children: [
                             Text(
                               'Seats',
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodySmall?.copyWith(
-                                color: colorScheme.onSurface.withOpacity(0.6),
-                              ),
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: colorScheme.onSurface.withOpacity(
+                                      0.6,
+                                    ),
+                                  ),
                             ),
                             Text(
                               '${_car!.seats} people',
@@ -1785,20 +1768,20 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                           children: [
                             Text(
                               'Daily rate',
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodySmall?.copyWith(
-                                color: colorScheme.onSurface.withOpacity(0.6),
-                              ),
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: colorScheme.onSurface.withOpacity(
+                                      0.6,
+                                    ),
+                                  ),
                             ),
                             Text(
                               _car!.displayPrice,
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodyMedium?.copyWith(
-                                color: colorScheme.primary,
-                                fontWeight: FontWeight.bold,
-                              ),
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: colorScheme.primary,
+                                    fontWeight: FontWeight.bold,
+                                  ),
                             ),
                           ],
                         ),
@@ -1822,59 +1805,55 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                   // Start Date
                   Expanded(
                     child: InkWell(
-                      onTap:
-                          _isBooking
-                              ? null
-                              : () async {
-                                final now = DateTime.now();
-                                final tomorrow = DateTime(
-                                  now.year,
-                                  now.month,
-                                  now.day + 1,
-                                );
+                      onTap: _isBooking
+                          ? null
+                          : () async {
+                              final now = DateTime.now();
+                              final tomorrow = DateTime(
+                                now.year,
+                                now.month,
+                                now.day + 1,
+                              );
 
-                                final date = await showDatePicker(
-                                  context: context,
-                                  initialDate: _selectedStartDate ?? tomorrow,
-                                  firstDate: tomorrow,
-                                  lastDate: DateTime.now().add(
-                                    const Duration(days: 365),
-                                  ),
-                                );
-                                if (date != null) {
-                                  setState(() {
-                                    _selectedStartDate = date;
+                              final date = await showDatePicker(
+                                context: context,
+                                initialDate: _selectedStartDate ?? tomorrow,
+                                firstDate: tomorrow,
+                                lastDate: DateTime.now().add(
+                                  const Duration(days: 365),
+                                ),
+                              );
+                              if (date != null) {
+                                setState(() {
+                                  _selectedStartDate = date;
 
-                                    // If end date exists but is now before or same as start date,
-                                    // set it to start date + 1 day
-                                    if (_selectedEndDate == null ||
-                                        !_selectedEndDate!.isAfter(
-                                          _selectedStartDate!,
-                                        )) {
-                                      _selectedEndDate = _selectedStartDate!
-                                          .add(const Duration(days: 1));
-                                    }
+                                  // If end date exists but is now before or same as start date,
+                                  // set it to start date + 1 day
+                                  if (_selectedEndDate == null ||
+                                      !_selectedEndDate!.isAfter(
+                                        _selectedStartDate!,
+                                      )) {
+                                    _selectedEndDate = _selectedStartDate!.add(
+                                      const Duration(days: 1),
+                                    );
+                                  }
 
-                                    // Reset availability info when dates change
-                                    _availability = null;
-                                    _availabilityErrorMessage = null;
-                                  });
-                                }
-                              },
+                                  // Reset availability info when dates change
+                                  _availability = null;
+                                  _availabilityErrorMessage = null;
+                                });
+                              }
+                            },
                       child: Container(
                         padding: const EdgeInsets.all(16),
                         decoration: BoxDecoration(
-                          color:
-                              _selectedStartDate != null
-                                  ? colorScheme.primaryContainer.withOpacity(
-                                    0.3,
-                                  )
-                                  : colorScheme.surfaceContainerLow,
+                          color: _selectedStartDate != null
+                              ? colorScheme.primaryContainer.withOpacity(0.3)
+                              : colorScheme.surfaceContainerLow,
                           border: Border.all(
-                            color:
-                                _selectedStartDate != null
-                                    ? colorScheme.primary.withOpacity(0.5)
-                                    : colorScheme.outline.withOpacity(0.3),
+                            color: _selectedStartDate != null
+                                ? colorScheme.primary.withOpacity(0.5)
+                                : colorScheme.outline.withOpacity(0.3),
                           ),
                           borderRadius: BorderRadius.circular(12),
                         ),
@@ -1882,33 +1861,29 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                           children: [
                             Icon(
                               Icons.calendar_today_rounded,
-                              color:
-                                  _selectedStartDate != null
-                                      ? colorScheme.primary
-                                      : colorScheme.outline,
+                              color: _selectedStartDate != null
+                                  ? colorScheme.primary
+                                  : colorScheme.outline,
                             ),
                             const SizedBox(width: 8),
                             Expanded(
                               child: Text(
                                 _selectedStartDate != null
                                     ? DateFormat(
-                                      'MMM d, yyyy',
-                                    ).format(_selectedStartDate!)
+                                        'MMM d, yyyy',
+                                      ).format(_selectedStartDate!)
                                     : 'Start date',
-                                style: Theme.of(
-                                  context,
-                                ).textTheme.bodyLarge?.copyWith(
-                                  color:
-                                      _selectedStartDate != null
+                                style: Theme.of(context).textTheme.bodyLarge
+                                    ?.copyWith(
+                                      color: _selectedStartDate != null
                                           ? colorScheme.onSurface
                                           : colorScheme.onSurface.withOpacity(
-                                            0.6,
-                                          ),
-                                  fontWeight:
-                                      _selectedStartDate != null
+                                              0.6,
+                                            ),
+                                      fontWeight: _selectedStartDate != null
                                           ? FontWeight.w600
                                           : FontWeight.normal,
-                                ),
+                                    ),
                               ),
                             ),
                           ],
@@ -1921,54 +1896,49 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                   // End Date
                   Expanded(
                     child: InkWell(
-                      onTap:
-                          _isBooking || _selectedStartDate == null
-                              ? null
-                              : () async {
-                                // Set the mininum end date to start date + 1 day
-                                final minimumEndDate = _selectedStartDate!.add(
-                                  const Duration(days: 1),
-                                );
+                      onTap: _isBooking || _selectedStartDate == null
+                          ? null
+                          : () async {
+                              // Set the mininum end date to start date + 1 day
+                              final minimumEndDate = _selectedStartDate!.add(
+                                const Duration(days: 1),
+                              );
 
-                                final date = await showDatePicker(
-                                  context: context,
-                                  initialDate:
-                                      _selectedEndDate != null &&
-                                              _selectedEndDate!.isAfter(
-                                                minimumEndDate,
-                                              )
-                                          ? _selectedEndDate!
-                                          : minimumEndDate,
-                                  firstDate: minimumEndDate,
-                                  lastDate: _selectedStartDate!.add(
-                                    const Duration(
-                                      days: 30,
-                                    ), // Maximum 30-day booking
-                                  ),
-                                );
-                                if (date != null) {
-                                  setState(() {
-                                    _selectedEndDate = date;
-                                    // Reset availability info when dates change
-                                    _availability = null;
-                                    _availabilityErrorMessage = null;
-                                  });
-                                }
-                              },
+                              final date = await showDatePicker(
+                                context: context,
+                                initialDate:
+                                    _selectedEndDate != null &&
+                                        _selectedEndDate!.isAfter(
+                                          minimumEndDate,
+                                        )
+                                    ? _selectedEndDate!
+                                    : minimumEndDate,
+                                firstDate: minimumEndDate,
+                                lastDate: _selectedStartDate!.add(
+                                  const Duration(
+                                    days: 30,
+                                  ), // Maximum 30-day booking
+                                ),
+                              );
+                              if (date != null) {
+                                setState(() {
+                                  _selectedEndDate = date;
+                                  // Reset availability info when dates change
+                                  _availability = null;
+                                  _availabilityErrorMessage = null;
+                                });
+                              }
+                            },
                       child: Container(
                         padding: const EdgeInsets.all(16),
                         decoration: BoxDecoration(
-                          color:
-                              _selectedEndDate != null
-                                  ? colorScheme.primaryContainer.withOpacity(
-                                    0.3,
-                                  )
-                                  : colorScheme.surfaceContainerLow,
+                          color: _selectedEndDate != null
+                              ? colorScheme.primaryContainer.withOpacity(0.3)
+                              : colorScheme.surfaceContainerLow,
                           border: Border.all(
-                            color:
-                                _selectedEndDate != null
-                                    ? colorScheme.primary.withOpacity(0.5)
-                                    : colorScheme.outline.withOpacity(0.3),
+                            color: _selectedEndDate != null
+                                ? colorScheme.primary.withOpacity(0.5)
+                                : colorScheme.outline.withOpacity(0.3),
                           ),
                           borderRadius: BorderRadius.circular(12),
                         ),
@@ -1976,33 +1946,29 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                           children: [
                             Icon(
                               Icons.calendar_today_rounded,
-                              color:
-                                  _selectedEndDate != null
-                                      ? colorScheme.primary
-                                      : colorScheme.outline,
+                              color: _selectedEndDate != null
+                                  ? colorScheme.primary
+                                  : colorScheme.outline,
                             ),
                             const SizedBox(width: 8),
                             Expanded(
                               child: Text(
                                 _selectedEndDate != null
                                     ? DateFormat(
-                                      'MMM d, yyyy',
-                                    ).format(_selectedEndDate!)
+                                        'MMM d, yyyy',
+                                      ).format(_selectedEndDate!)
                                     : 'End date',
-                                style: Theme.of(
-                                  context,
-                                ).textTheme.bodyLarge?.copyWith(
-                                  color:
-                                      _selectedEndDate != null
+                                style: Theme.of(context).textTheme.bodyLarge
+                                    ?.copyWith(
+                                      color: _selectedEndDate != null
                                           ? colorScheme.onSurface
                                           : colorScheme.onSurface.withOpacity(
-                                            0.6,
-                                          ),
-                                  fontWeight:
-                                      _selectedEndDate != null
+                                              0.6,
+                                            ),
+                                      fontWeight: _selectedEndDate != null
                                           ? FontWeight.w600
                                           : FontWeight.normal,
-                                ),
+                                    ),
                               ),
                             ),
                           ],
@@ -2055,18 +2021,16 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                 SizedBox(
                   width: double.infinity,
                   child: OutlinedButton.icon(
-                    onPressed:
-                        _isBooking || _isCheckingAvailability
-                            ? null
-                            : _checkAvailability,
-                    icon:
-                        _isCheckingAvailability
-                            ? const SizedBox(
-                              width: 20,
-                              height: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                            : const Icon(Icons.search_rounded),
+                    onPressed: _isBooking || _isCheckingAvailability
+                        ? null
+                        : _checkAvailability,
+                    icon: _isCheckingAvailability
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.search_rounded),
                     label: Text(
                       _isCheckingAvailability
                           ? 'Checking...'
@@ -2088,10 +2052,9 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                   duration: const Duration(milliseconds: 500),
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
-                    color:
-                        _availability!.isAvailable
-                            ? Colors.green.withOpacity(0.1)
-                            : Colors.red.withOpacity(0.1),
+                    color: _availability!.isAvailable
+                        ? Colors.green.withOpacity(0.1)
+                        : Colors.red.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(12),
                     border: Border.all(
                       color: _availability!.statusColor.withOpacity(0.3),
@@ -2115,12 +2078,11 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                           Expanded(
                             child: Text(
                               _availability!.statusText,
-                              style: Theme.of(
-                                context,
-                              ).textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: _availability!.statusColor,
-                              ),
+                              style: Theme.of(context).textTheme.titleMedium
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: _availability!.statusColor,
+                                  ),
                             ),
                           ),
                         ],
@@ -2136,12 +2098,11 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                             ),
                             Text(
                               _availability!.formattedPrice,
-                              style: Theme.of(
-                                context,
-                              ).textTheme.titleLarge?.copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: colorScheme.primary,
-                              ),
+                              style: Theme.of(context).textTheme.titleLarge
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: colorScheme.primary,
+                                  ),
                             ),
                           ],
                         ),
@@ -2151,11 +2112,12 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                           children: [
                             Text(
                               'Duration:',
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodyMedium?.copyWith(
-                                color: colorScheme.onSurface.withOpacity(0.7),
-                              ),
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: colorScheme.onSurface.withOpacity(
+                                      0.7,
+                                    ),
+                                  ),
                             ),
                             Text(
                               _availability!.formattedDuration,
@@ -2208,28 +2170,26 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                   children: [
                     Checkbox(
                       value: _agreedToTerms,
-                      onChanged:
-                          _isBooking
-                              ? null
-                              : (value) {
-                                setState(() {
-                                  _agreedToTerms = value ?? false;
-                                });
-                                HapticFeedback.lightImpact();
-                              },
+                      onChanged: _isBooking
+                          ? null
+                          : (value) {
+                              setState(() {
+                                _agreedToTerms = value ?? false;
+                              });
+                              HapticFeedback.lightImpact();
+                            },
                     ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: GestureDetector(
-                        onTap:
-                            _isBooking
-                                ? null
-                                : () {
-                                  setState(() {
-                                    _agreedToTerms = !_agreedToTerms;
-                                  });
-                                  HapticFeedback.lightImpact();
-                                },
+                        onTap: _isBooking
+                            ? null
+                            : () {
+                                setState(() {
+                                  _agreedToTerms = !_agreedToTerms;
+                                });
+                                HapticFeedback.lightImpact();
+                              },
                         child: Text(
                           'I agree to the terms and conditions and privacy policy',
                           style: Theme.of(
@@ -2250,17 +2210,15 @@ class _CarDetailsScreenState extends State<CarDetailsScreen>
                   child: AnimatedContainer(
                     duration: const Duration(milliseconds: 200),
                     child: CustomButton(
-                      onPressed:
-                          _isBooking || !_agreedToTerms
-                              ? null
-                              : _proceedWithBooking,
+                      onPressed: _isBooking || !_agreedToTerms
+                          ? null
+                          : _proceedWithBooking,
                       isLoading: _isBooking,
                       minimumSize: const Size(double.infinity, 56),
                       borderRadius: 16,
-                      backgroundColor:
-                          _agreedToTerms
-                              ? colorScheme.primary
-                              : colorScheme.outline.withOpacity(0.5),
+                      backgroundColor: _agreedToTerms
+                          ? colorScheme.primary
+                          : colorScheme.outline.withOpacity(0.5),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
@@ -2495,12 +2453,11 @@ class _BookingSuccessDialogState extends State<BookingSuccessDialog>
                   children: [
                     Text(
                       'Booking Confirmed!',
-                      style: Theme.of(
-                        context,
-                      ).textTheme.headlineSmall?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: colorScheme.onSurface,
-                      ),
+                      style: Theme.of(context).textTheme.headlineSmall
+                          ?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: colorScheme.onSurface,
+                          ),
                     ),
                     const SizedBox(height: 8),
                     Text(
@@ -2530,12 +2487,11 @@ class CheckPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     if (animationValue == 0) return;
 
-    final paint =
-        Paint()
-          ..color = Colors.white
-          ..strokeWidth = 4
-          ..style = PaintingStyle.stroke
-          ..strokeCap = StrokeCap.round;
+    final paint = Paint()
+      ..color = Colors.white
+      ..strokeWidth = 4
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
 
     final center = Offset(size.width / 2, size.height / 2);
 

--- a/lib/screens/cars/car_list_screen.dart
+++ b/lib/screens/cars/car_list_screen.dart
@@ -4,6 +4,8 @@ import '../../models/car_models.dart';
 import '../../services/car_service.dart';
 import 'car_details_screen.dart';
 
+import "../../widgets/seamless_page_route.dart";
+
 class CarListScreen extends StatefulWidget {
   const CarListScreen({super.key});
 
@@ -119,8 +121,9 @@ class _CarListScreenState extends State<CarListScreen>
 
     try {
       final filter = CarFilterRequest(
-        searchTerm:
-            _searchController.text.isNotEmpty ? _searchController.text : null,
+        searchTerm: _searchController.text.isNotEmpty
+            ? _searchController.text
+            : null,
         make: _selectedMake,
         model: _selectedModel,
         category: _selectedCategory,
@@ -171,8 +174,9 @@ class _CarListScreenState extends State<CarListScreen>
 
     try {
       final filter = CarFilterRequest(
-        searchTerm:
-            _searchController.text.isNotEmpty ? _searchController.text : null,
+        searchTerm: _searchController.text.isNotEmpty
+            ? _searchController.text
+            : null,
         make: _selectedMake,
         model: _selectedModel,
         category: _selectedCategory,
@@ -479,22 +483,20 @@ class _CarListScreenState extends State<CarListScreen>
             color: colorScheme.surfaceContainerLow,
             borderRadius: BorderRadius.circular(16),
             border: Border.all(
-              color:
-                  _isSearchFocused
-                      ? colorScheme.primary
-                      : colorScheme.outline.withOpacity(0.2),
+              color: _isSearchFocused
+                  ? colorScheme.primary
+                  : colorScheme.outline.withOpacity(0.2),
               width: _isSearchFocused ? 2 : 1,
             ),
-            boxShadow:
-                _isSearchFocused
-                    ? [
-                      BoxShadow(
-                        color: colorScheme.primary.withOpacity(0.1),
-                        blurRadius: 8,
-                        offset: const Offset(0, 2),
-                      ),
-                    ]
-                    : null,
+            boxShadow: _isSearchFocused
+                ? [
+                    BoxShadow(
+                      color: colorScheme.primary.withOpacity(0.1),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                  ]
+                : null,
           ),
           child: Focus(
             onFocusChange: (hasFocus) {
@@ -511,27 +513,25 @@ class _CarListScreenState extends State<CarListScreen>
                 ),
                 prefixIcon: Icon(
                   Icons.search_rounded,
-                  color:
-                      _isSearchFocused
-                          ? colorScheme.primary
-                          : colorScheme.outline,
+                  color: _isSearchFocused
+                      ? colorScheme.primary
+                      : colorScheme.outline,
                 ),
                 border: InputBorder.none,
                 contentPadding: const EdgeInsets.symmetric(
                   horizontal: 20,
                   vertical: 16,
                 ),
-                suffixIcon:
-                    _searchController.text.isNotEmpty
-                        ? IconButton(
-                          onPressed: () {
-                            _searchController.clear();
-                            _loadCars(isRefresh: true);
-                          },
-                          icon: const Icon(Icons.clear_rounded),
-                          color: colorScheme.outline,
-                        )
-                        : null,
+                suffixIcon: _searchController.text.isNotEmpty
+                    ? IconButton(
+                        onPressed: () {
+                          _searchController.clear();
+                          _loadCars(isRefresh: true);
+                        },
+                        icon: const Icon(Icons.clear_rounded),
+                        color: colorScheme.outline,
+                      )
+                    : null,
               ),
               onSubmitted: (_) => _loadCars(isRefresh: true),
               onChanged: (value) {
@@ -638,37 +638,33 @@ class _CarListScreenState extends State<CarListScreen>
           duration: const Duration(milliseconds: 200),
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           decoration: BoxDecoration(
-            color:
-                selectedDate != null
-                    ? colorScheme.primary.withOpacity(0.1)
-                    : colorScheme.surfaceContainerLow,
+            color: selectedDate != null
+                ? colorScheme.primary.withOpacity(0.1)
+                : colorScheme.surfaceContainerLow,
             borderRadius: BorderRadius.circular(12),
             border: Border.all(
-              color:
-                  selectedDate != null
-                      ? colorScheme.primary.withOpacity(0.3)
-                      : colorScheme.outline.withOpacity(0.2),
+              color: selectedDate != null
+                  ? colorScheme.primary.withOpacity(0.3)
+                  : colorScheme.outline.withOpacity(0.2),
             ),
-            boxShadow:
-                selectedDate != null
-                    ? [
-                      BoxShadow(
-                        color: colorScheme.primary.withOpacity(0.05),
-                        blurRadius: 4,
-                        offset: const Offset(0, 1),
-                      ),
-                    ]
-                    : null,
+            boxShadow: selectedDate != null
+                ? [
+                    BoxShadow(
+                      color: colorScheme.primary.withOpacity(0.05),
+                      blurRadius: 4,
+                      offset: const Offset(0, 1),
+                    ),
+                  ]
+                : null,
           ),
           child: Row(
             children: [
               Icon(
                 icon,
                 size: 18,
-                color:
-                    selectedDate != null
-                        ? colorScheme.primary
-                        : colorScheme.outline,
+                color: selectedDate != null
+                    ? colorScheme.primary
+                    : colorScheme.outline,
               ),
               const SizedBox(width: 8),
               Expanded(
@@ -687,10 +683,9 @@ class _CarListScreenState extends State<CarListScreen>
                           : 'Select date',
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         fontWeight: FontWeight.w500,
-                        color:
-                            selectedDate != null
-                                ? colorScheme.onSurface
-                                : colorScheme.onSurface.withOpacity(0.6),
+                        color: selectedDate != null
+                            ? colorScheme.onSurface
+                            : colorScheme.onSurface.withOpacity(0.6),
                       ),
                     ),
                   ],
@@ -722,33 +717,31 @@ class _CarListScreenState extends State<CarListScreen>
             color: isSelected ? colorScheme.primary : colorScheme.surface,
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color:
-                  isSelected
-                      ? colorScheme.primary
-                      : colorScheme.outline.withOpacity(0.3),
+              color: isSelected
+                  ? colorScheme.primary
+                  : colorScheme.outline.withOpacity(0.3),
               width: isSelected ? 2 : 1,
             ),
-            boxShadow:
-                isSelected
-                    ? [
-                      BoxShadow(
-                        color: colorScheme.primary.withOpacity(0.2),
-                        blurRadius: 8,
-                        offset: const Offset(0, 2),
-                      ),
-                      BoxShadow(
-                        color: colorScheme.primary.withOpacity(0.1),
-                        blurRadius: 4,
-                        offset: const Offset(0, 1),
-                      ),
-                    ]
-                    : [
-                      BoxShadow(
-                        color: Colors.black.withOpacity(0.05),
-                        blurRadius: 2,
-                        offset: const Offset(0, 1),
-                      ),
-                    ],
+            boxShadow: isSelected
+                ? [
+                    BoxShadow(
+                      color: colorScheme.primary.withOpacity(0.2),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                    BoxShadow(
+                      color: colorScheme.primary.withOpacity(0.1),
+                      blurRadius: 4,
+                      offset: const Offset(0, 1),
+                    ),
+                  ]
+                : [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.05),
+                      blurRadius: 2,
+                      offset: const Offset(0, 1),
+                    ),
+                  ],
           ),
           child: Text(
             label,
@@ -778,16 +771,14 @@ class _CarListScreenState extends State<CarListScreen>
           duration: const Duration(milliseconds: 200),
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
           decoration: BoxDecoration(
-            color:
-                _showFilters
-                    ? colorScheme.primary.withOpacity(0.1)
-                    : colorScheme.surface,
+            color: _showFilters
+                ? colorScheme.primary.withOpacity(0.1)
+                : colorScheme.surface,
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
-              color:
-                  _showFilters
-                      ? colorScheme.primary
-                      : colorScheme.outline.withOpacity(0.3),
+              color: _showFilters
+                  ? colorScheme.primary
+                  : colorScheme.outline.withOpacity(0.3),
               width: _showFilters ? 2 : 1,
             ),
             boxShadow: [
@@ -921,9 +912,8 @@ class _CarListScreenState extends State<CarListScreen>
                       border: InputBorder.none,
                       contentPadding: const EdgeInsets.symmetric(vertical: 8),
                     ),
-                    onChanged:
-                        (value) =>
-                            _selectedModel = value.isNotEmpty ? value : null,
+                    onChanged: (value) =>
+                        _selectedModel = value.isNotEmpty ? value : null,
                   ),
                 ),
               ),
@@ -953,9 +943,8 @@ class _CarListScreenState extends State<CarListScreen>
                         ),
                       ),
                     ],
-                    onChanged:
-                        (value) =>
-                            setState(() => _selectedTransmission = value),
+                    onChanged: (value) =>
+                        setState(() => _selectedTransmission = value),
                   ),
                 ),
               ),
@@ -980,8 +969,8 @@ class _CarListScreenState extends State<CarListScreen>
                         ),
                       ),
                     ],
-                    onChanged:
-                        (value) => setState(() => _selectedFuelType = value),
+                    onChanged: (value) =>
+                        setState(() => _selectedFuelType = value),
                   ),
                 ),
               ),
@@ -1097,17 +1086,16 @@ class _CarListScreenState extends State<CarListScreen>
                   value: _sortBy,
                   isExpanded: true,
                   underline: const SizedBox(),
-                  items:
-                      CarService.sortOptions
-                          .map(
-                            (option) => DropdownMenuItem<String>(
-                              value: option,
-                              child: Text(
-                                option.replaceAll('_', ' ').toUpperCase(),
-                              ),
-                            ),
-                          )
-                          .toList(),
+                  items: CarService.sortOptions
+                      .map(
+                        (option) => DropdownMenuItem<String>(
+                          value: option,
+                          child: Text(
+                            option.replaceAll('_', ' ').toUpperCase(),
+                          ),
+                        ),
+                      )
+                      .toList(),
                   onChanged: (value) => setState(() => _sortBy = value!),
                 ),
                 const SizedBox(height: 8),
@@ -1115,8 +1103,8 @@ class _CarListScreenState extends State<CarListScreen>
                   children: [
                     Checkbox(
                       value: _sortAscending,
-                      onChanged:
-                          (value) => setState(() => _sortAscending = value!),
+                      onChanged: (value) =>
+                          setState(() => _sortAscending = value!),
                     ),
                     Text(
                       'Ascending order',
@@ -1169,10 +1157,9 @@ class _CarListScreenState extends State<CarListScreen>
   }) {
     return TextField(
       controller: TextEditingController(text: value),
-      keyboardType:
-          isInt
-              ? TextInputType.number
-              : const TextInputType.numberWithOptions(decimal: true),
+      keyboardType: isInt
+          ? TextInputType.number
+          : const TextInputType.numberWithOptions(decimal: true),
       decoration: InputDecoration(
         hintText: hint,
         border: InputBorder.none,
@@ -1348,35 +1335,9 @@ class _CarListScreenState extends State<CarListScreen>
               child: InkWell(
                 onTap: () {
                   HapticFeedback.mediumImpact();
-                  Navigator.of(context).push(
-                    PageRouteBuilder(
-                      pageBuilder:
-                          (context, animation, secondaryAnimation) =>
-                              CarDetailsScreen(carId: car.id),
-                      transitionsBuilder: (
-                        context,
-                        animation,
-                        secondaryAnimation,
-                        child,
-                      ) {
-                        return SlideTransition(
-                          position: Tween<Offset>(
-                            begin: const Offset(1.0, 0.0),
-                            end: Offset.zero,
-                          ).animate(
-                            CurvedAnimation(
-                              parent: animation,
-                              curve: Curves.easeOutCubic,
-                            ),
-                          ),
-                          child: FadeTransition(
-                            opacity: animation,
-                            child: child,
-                          ),
-                        );
-                      },
-                      transitionDuration: const Duration(milliseconds: 400),
-                    ),
+                  showSeamlessPage(
+                    context,
+                    (context) => CarDetailsScreen(carId: car.id),
                   );
                 },
                 borderRadius: BorderRadius.circular(isDesktop ? 24 : 20),
@@ -1403,77 +1364,72 @@ class _CarListScreenState extends State<CarListScreen>
                           ),
                           child:
                               car.mainImageUrl != null &&
-                                      car.mainImageUrl!.isNotEmpty
-                                  ? ClipRRect(
-                                    borderRadius: BorderRadius.only(
-                                      topLeft: Radius.circular(
-                                        isDesktop ? 24 : 20,
-                                      ),
-                                      topRight: Radius.circular(
-                                        isDesktop ? 24 : 20,
-                                      ),
+                                  car.mainImageUrl!.isNotEmpty
+                              ? ClipRRect(
+                                  borderRadius: BorderRadius.only(
+                                    topLeft: Radius.circular(
+                                      isDesktop ? 24 : 20,
                                     ),
-                                    child: Image.network(
-                                      car.mainImageUrl!,
-                                      fit: BoxFit.cover,
-                                      width: double.infinity,
-                                      height: isDesktop ? 220 : 180,
-                                      errorBuilder:
-                                          (context, error, stackTrace) =>
-                                              _buildImagePlaceholder(),
-                                      loadingBuilder: (
-                                        context,
-                                        child,
-                                        loadingProgress,
-                                      ) {
-                                        if (loadingProgress == null)
-                                          return child;
-                                        return Container(
-                                          height: isDesktop ? 220 : 180,
-                                          decoration: BoxDecoration(
-                                            gradient: LinearGradient(
-                                              colors: [
-                                                colorScheme.surfaceContainer,
-                                                colorScheme.surfaceContainer
-                                                    .withOpacity(0.7),
-                                              ],
-                                            ),
-                                          ),
-                                          child: Center(
-                                            child: Column(
-                                              mainAxisAlignment:
-                                                  MainAxisAlignment.center,
-                                              children: [
-                                                CircularProgressIndicator(
-                                                  value:
-                                                      loadingProgress
-                                                                  .expectedTotalBytes !=
-                                                              null
-                                                          ? loadingProgress
-                                                                  .cumulativeBytesLoaded /
-                                                              loadingProgress
-                                                                  .expectedTotalBytes!
-                                                          : null,
-                                                  strokeWidth: 2,
-                                                  color: colorScheme.primary,
-                                                ),
-                                                const SizedBox(height: 8),
-                                                Text(
-                                                  'Loading...',
-                                                  style: TextStyle(
-                                                    color: colorScheme.onSurface
-                                                        .withOpacity(0.6),
-                                                    fontSize: 12,
-                                                  ),
-                                                ),
-                                              ],
-                                            ),
-                                          ),
-                                        );
-                                      },
+                                    topRight: Radius.circular(
+                                      isDesktop ? 24 : 20,
                                     ),
-                                  )
-                                  : _buildImagePlaceholder(),
+                                  ),
+                                  child: Image.network(
+                                    car.mainImageUrl!,
+                                    fit: BoxFit.cover,
+                                    width: double.infinity,
+                                    height: isDesktop ? 220 : 180,
+                                    errorBuilder:
+                                        (context, error, stackTrace) =>
+                                            _buildImagePlaceholder(),
+                                    loadingBuilder: (context, child, loadingProgress) {
+                                      if (loadingProgress == null) return child;
+                                      return Container(
+                                        height: isDesktop ? 220 : 180,
+                                        decoration: BoxDecoration(
+                                          gradient: LinearGradient(
+                                            colors: [
+                                              colorScheme.surfaceContainer,
+                                              colorScheme.surfaceContainer
+                                                  .withOpacity(0.7),
+                                            ],
+                                          ),
+                                        ),
+                                        child: Center(
+                                          child: Column(
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.center,
+                                            children: [
+                                              CircularProgressIndicator(
+                                                value:
+                                                    loadingProgress
+                                                            .expectedTotalBytes !=
+                                                        null
+                                                    ? loadingProgress
+                                                              .cumulativeBytesLoaded /
+                                                          loadingProgress
+                                                              .expectedTotalBytes!
+                                                    : null,
+                                                strokeWidth: 2,
+                                                color: colorScheme.primary,
+                                              ),
+                                              const SizedBox(height: 8),
+                                              Text(
+                                                'Loading...',
+                                                style: TextStyle(
+                                                  color: colorScheme.onSurface
+                                                      .withOpacity(0.6),
+                                                  fontSize: 12,
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                  ),
+                                )
+                              : _buildImagePlaceholder(),
                         ),
 
                         // Gradient overlay for better text readability
@@ -1537,8 +1493,9 @@ class _CarListScreenState extends State<CarListScreen>
                               vertical: 4,
                             ),
                             decoration: BoxDecoration(
-                              color:
-                                  car.isAvailable ? Colors.green : Colors.red,
+                              color: car.isAvailable
+                                  ? Colors.green
+                                  : Colors.red,
                               borderRadius: BorderRadius.circular(12),
                             ),
                             child: Text(
@@ -1567,13 +1524,14 @@ class _CarListScreenState extends State<CarListScreen>
                                 Expanded(
                                   child: Text(
                                     '${car.make} ${car.model}',
-                                    style: Theme.of(
-                                      context,
-                                    ).textTheme.titleMedium?.copyWith(
-                                      fontWeight: FontWeight.bold,
-                                      height: 1.2,
-                                      fontSize: isDesktop ? 18 : 16,
-                                    ),
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium
+                                        ?.copyWith(
+                                          fontWeight: FontWeight.bold,
+                                          height: 1.2,
+                                          fontSize: isDesktop ? 18 : 16,
+                                        ),
                                     maxLines: 1,
                                     overflow: TextOverflow.ellipsis,
                                   ),
@@ -1612,14 +1570,12 @@ class _CarListScreenState extends State<CarListScreen>
                                 Expanded(
                                   child: Text(
                                     car.location,
-                                    style: Theme.of(
-                                      context,
-                                    ).textTheme.bodySmall?.copyWith(
-                                      color: colorScheme.onSurface.withOpacity(
-                                        0.7,
-                                      ),
-                                      fontSize: isDesktop ? 14 : 12,
-                                    ),
+                                    style: Theme.of(context).textTheme.bodySmall
+                                        ?.copyWith(
+                                          color: colorScheme.onSurface
+                                              .withOpacity(0.7),
+                                          fontSize: isDesktop ? 14 : 12,
+                                        ),
                                     maxLines: 1,
                                     overflow: TextOverflow.ellipsis,
                                   ),
@@ -1769,25 +1725,27 @@ class _CarListScreenState extends State<CarListScreen>
                                     children: [
                                       Text(
                                         'Daily Rate',
-                                        style: Theme.of(
-                                          context,
-                                        ).textTheme.bodySmall?.copyWith(
-                                          color: colorScheme.onSurface
-                                              .withOpacity(0.6),
-                                          fontSize: isDesktop ? 12 : 11,
-                                        ),
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodySmall
+                                            ?.copyWith(
+                                              color: colorScheme.onSurface
+                                                  .withOpacity(0.6),
+                                              fontSize: isDesktop ? 12 : 11,
+                                            ),
                                       ),
                                       Row(
                                         children: [
                                           Text(
                                             car.displayPrice,
-                                            style: Theme.of(
-                                              context,
-                                            ).textTheme.titleLarge?.copyWith(
-                                              color: colorScheme.primary,
-                                              fontWeight: FontWeight.bold,
-                                              fontSize: isDesktop ? 22 : 18,
-                                            ),
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .titleLarge
+                                                ?.copyWith(
+                                                  color: colorScheme.primary,
+                                                  fontWeight: FontWeight.bold,
+                                                  fontSize: isDesktop ? 22 : 18,
+                                                ),
                                           ),
                                           if (isDesktop) ...[
                                             const SizedBox(width: 4),
@@ -1820,102 +1778,64 @@ class _CarListScreenState extends State<CarListScreen>
                                 // Book Now Button
                                 AnimatedContainer(
                                   duration: const Duration(milliseconds: 200),
-                                  child:
-                                      car.isAvailable
-                                          ? FilledButton.icon(
-                                            onPressed: () {
-                                              HapticFeedback.lightImpact();
-                                              Navigator.of(context).push(
-                                                PageRouteBuilder(
-                                                  pageBuilder:
-                                                      (
-                                                        context,
-                                                        animation,
-                                                        secondaryAnimation,
-                                                      ) => CarDetailsScreen(
-                                                        carId: car.id,
-                                                      ),
-                                                  transitionsBuilder: (
-                                                    context,
-                                                    animation,
-                                                    secondaryAnimation,
-                                                    child,
-                                                  ) {
-                                                    return SlideTransition(
-                                                      position: Tween<Offset>(
-                                                        begin: const Offset(
-                                                          1.0,
-                                                          0.0,
-                                                        ),
-                                                        end: Offset.zero,
-                                                      ).animate(
-                                                        CurvedAnimation(
-                                                          parent: animation,
-                                                          curve:
-                                                              Curves
-                                                                  .easeOutCubic,
-                                                        ),
-                                                      ),
-                                                      child: FadeTransition(
-                                                        opacity: animation,
-                                                        child: child,
-                                                      ),
-                                                    );
-                                                  },
-                                                  transitionDuration:
-                                                      const Duration(
-                                                        milliseconds: 400,
-                                                      ),
-                                                ),
-                                              );
-                                            },
-                                            style: FilledButton.styleFrom(
-                                              padding: EdgeInsets.symmetric(
-                                                horizontal: isDesktop ? 24 : 20,
-                                                vertical: isDesktop ? 14 : 12,
+                                  child: car.isAvailable
+                                      ? FilledButton.icon(
+                                          onPressed: () {
+                                            HapticFeedback.lightImpact();
+                                            showSeamlessPage(
+                                              context,
+                                              (context) => CarDetailsScreen(
+                                                carId: car.id,
                                               ),
-                                              shape: RoundedRectangleBorder(
-                                                borderRadius:
-                                                    BorderRadius.circular(
-                                                      isDesktop ? 16 : 12,
-                                                    ),
-                                              ),
-                                              elevation: isDesktop ? 4 : 2,
+                                            );
+                                          },
+                                          style: FilledButton.styleFrom(
+                                            padding: EdgeInsets.symmetric(
+                                              horizontal: isDesktop ? 24 : 20,
+                                              vertical: isDesktop ? 14 : 12,
                                             ),
-                                            icon: Icon(
-                                              Icons.drive_eta_rounded,
-                                              size: isDesktop ? 18 : 16,
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(
+                                                    isDesktop ? 16 : 12,
+                                                  ),
                                             ),
-                                            label: Text(
-                                              isDesktop ? 'Book Now' : 'Rent',
-                                              style: TextStyle(
-                                                fontWeight: FontWeight.w600,
-                                                fontSize: isDesktop ? 14 : 13,
-                                              ),
-                                            ),
-                                          )
-                                          : OutlinedButton(
-                                            onPressed: null,
-                                            style: OutlinedButton.styleFrom(
-                                              padding: EdgeInsets.symmetric(
-                                                horizontal: isDesktop ? 24 : 20,
-                                                vertical: isDesktop ? 14 : 12,
-                                              ),
-                                              shape: RoundedRectangleBorder(
-                                                borderRadius:
-                                                    BorderRadius.circular(
-                                                      isDesktop ? 16 : 12,
-                                                    ),
-                                              ),
-                                            ),
-                                            child: Text(
-                                              'Unavailable',
-                                              style: TextStyle(
-                                                fontWeight: FontWeight.w500,
-                                                fontSize: isDesktop ? 14 : 13,
-                                              ),
+                                            elevation: isDesktop ? 4 : 2,
+                                          ),
+                                          icon: Icon(
+                                            Icons.drive_eta_rounded,
+                                            size: isDesktop ? 18 : 16,
+                                          ),
+                                          label: Text(
+                                            isDesktop ? 'Book Now' : 'Rent',
+                                            style: TextStyle(
+                                              fontWeight: FontWeight.w600,
+                                              fontSize: isDesktop ? 14 : 13,
                                             ),
                                           ),
+                                        )
+                                      : OutlinedButton(
+                                          onPressed: null,
+                                          style: OutlinedButton.styleFrom(
+                                            padding: EdgeInsets.symmetric(
+                                              horizontal: isDesktop ? 24 : 20,
+                                              vertical: isDesktop ? 14 : 12,
+                                            ),
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(
+                                                    isDesktop ? 16 : 12,
+                                                  ),
+                                            ),
+                                          ),
+                                          child: Text(
+                                            'Unavailable',
+                                            style: TextStyle(
+                                              fontWeight: FontWeight.w500,
+                                              fontSize: isDesktop ? 14 : 13,
+                                            ),
+                                          ),
+                                        ),
                                 ),
                               ],
                             ),

--- a/lib/screens/tours/tour_details_screen.dart
+++ b/lib/screens/tours/tour_details_screen.dart
@@ -62,31 +62,32 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
     super.initState();
 
     _animationController = AnimationController(
-      duration: const Duration(milliseconds: 1000),
+      duration: const Duration(milliseconds: 600),
       vsync: this,
     );
     _fabController = AnimationController(
-      duration: const Duration(milliseconds: 600),
+      duration: const Duration(milliseconds: 400),
       vsync: this,
     );
     _staggerController = AnimationController(
-      duration: const Duration(milliseconds: 1200),
+      duration: const Duration(milliseconds: 800),
       vsync: this,
     );
     _bookingPanelController = AnimationController(
-      duration: const Duration(milliseconds: 600),
+      duration: const Duration(milliseconds: 400),
       vsync: this,
     );
 
     _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
       CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
     );
-    _slideAnimation = Tween<Offset>(
-      begin: const Offset(0, 0.5),
-      end: Offset.zero,
-    ).animate(
-      CurvedAnimation(parent: _animationController, curve: Curves.easeOutBack),
-    );
+    _slideAnimation =
+        Tween<Offset>(begin: const Offset(0, 0.5), end: Offset.zero).animate(
+          CurvedAnimation(
+            parent: _animationController,
+            curve: Curves.easeOutBack,
+          ),
+        );
     _scaleAnimation = Tween<double>(begin: 0.9, end: 1.0).animate(
       CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
     );
@@ -286,25 +287,20 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
         // Navigate to payment screen
         final result = await Navigator.of(context).push(
           PageRouteBuilder(
-            pageBuilder:
-                (context, animation, secondaryAnimation) =>
-                    PaymentScreen(paymentInfo: booking.paymentInfo!),
-            transitionsBuilder: (
-              context,
-              animation,
-              secondaryAnimation,
-              child,
-            ) {
-              return SlideTransition(
-                position: animation.drive(
-                  Tween(
-                    begin: const Offset(1.0, 0.0),
-                    end: Offset.zero,
-                  ).chain(CurveTween(curve: Curves.easeOutCubic)),
-                ),
-                child: child,
-              );
-            },
+            pageBuilder: (context, animation, secondaryAnimation) =>
+                PaymentScreen(paymentInfo: booking.paymentInfo!),
+            transitionsBuilder:
+                (context, animation, secondaryAnimation, child) {
+                  return SlideTransition(
+                    position: animation.drive(
+                      Tween(
+                        begin: const Offset(1.0, 0.0),
+                        end: Offset.zero,
+                      ).chain(CurveTween(curve: Curves.easeOutCubic)),
+                    ),
+                    child: child,
+                  );
+                },
           ),
         );
 
@@ -514,7 +510,9 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                             icon: AnimatedSwitcher(
                               duration: const Duration(milliseconds: 200),
                               child: Icon(
-                                _isFavorite ? Icons.favorite : Icons.favorite_border,
+                                _isFavorite
+                                    ? Icons.favorite
+                                    : Icons.favorite_border,
                                 key: ValueKey(_isFavorite),
                                 color: _isFavorite ? Colors.red : Colors.white,
                               ),
@@ -757,7 +755,9 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                             ),
                           );
                         },
-                        child: _buildEnhancedBookingPanel(showCloseButton: true),
+                        child: _buildEnhancedBookingPanel(
+                          showCloseButton: true,
+                        ),
                       ),
                     ),
                   ),
@@ -770,10 +770,9 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
   }
 
   Widget _buildEnhancedImageGallery() {
-    final images =
-        _tour!.images.isEmpty
-            ? [TourImage(id: 0, imageUrl: '', displayOrder: 0)]
-            : _tour!.images;
+    final images = _tour!.images.isEmpty
+        ? [TourImage(id: 0, imageUrl: '', displayOrder: 0)]
+        : _tour!.images;
 
     return Stack(
       children: [
@@ -796,8 +795,8 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                 child: Image.network(
                   image.imageUrl,
                   fit: BoxFit.cover,
-                  errorBuilder:
-                      (context, error, stackTrace) => _buildImagePlaceholder(),
+                  errorBuilder: (context, error, stackTrace) =>
+                      _buildImagePlaceholder(),
                 ),
               ),
             );
@@ -831,10 +830,9 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                       height: 8,
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(4),
-                        color:
-                            _currentImageIndex == index
-                                ? Colors.white
-                                : Colors.white.withOpacity(0.5),
+                        color: _currentImageIndex == index
+                            ? Colors.white
+                            : Colors.white.withOpacity(0.5),
                       ),
                     ),
                   ),
@@ -946,21 +944,19 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                     if (_tour!.hasDiscount)
                       Text(
                         _tour!.originalPrice,
-                        style: Theme.of(
-                          context,
-                        ).textTheme.titleMedium?.copyWith(
-                          decoration: TextDecoration.lineThrough,
-                          color: colorScheme.onSurface.withOpacity(0.6),
-                        ),
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(
+                              decoration: TextDecoration.lineThrough,
+                              color: colorScheme.onSurface.withOpacity(0.6),
+                            ),
                       ),
                     Text(
                       _tour!.displayPrice,
-                      style: Theme.of(
-                        context,
-                      ).textTheme.headlineMedium?.copyWith(
-                        color: colorScheme.primary,
-                        fontWeight: FontWeight.bold,
-                      ),
+                      style: Theme.of(context).textTheme.headlineMedium
+                          ?.copyWith(
+                            color: colorScheme.primary,
+                            fontWeight: FontWeight.bold,
+                          ),
                     ),
                   ],
                 ),
@@ -998,21 +994,19 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                     children: [
                       Text(
                         _tour!.originalPrice,
-                        style: Theme.of(
-                          context,
-                        ).textTheme.titleMedium?.copyWith(
-                          decoration: TextDecoration.lineThrough,
-                          color: colorScheme.onSurface.withOpacity(0.6),
-                        ),
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(
+                              decoration: TextDecoration.lineThrough,
+                              color: colorScheme.onSurface.withOpacity(0.6),
+                            ),
                       ),
                       Text(
                         _tour!.displayPrice,
-                        style: Theme.of(
-                          context,
-                        ).textTheme.headlineSmall?.copyWith(
-                          color: colorScheme.primary,
-                          fontWeight: FontWeight.bold,
-                        ),
+                        style: Theme.of(context).textTheme.headlineSmall
+                            ?.copyWith(
+                              color: colorScheme.primary,
+                              fontWeight: FontWeight.bold,
+                            ),
                       ),
                     ],
                   )
@@ -1312,12 +1306,11 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                         Expanded(
                           child: Text(
                             item.location!,
-                            style: Theme.of(
-                              context,
-                            ).textTheme.bodyMedium?.copyWith(
-                              color: colorScheme.primary,
-                              fontWeight: FontWeight.w500,
-                            ),
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(
+                                  color: colorScheme.primary,
+                                  fontWeight: FontWeight.w500,
+                                ),
                           ),
                         ),
                       ],
@@ -1558,12 +1551,11 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                       const SizedBox(height: 12),
                       Text(
                         'Interactive Map',
-                        style: Theme.of(
-                          context,
-                        ).textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: colorScheme.onSurface.withOpacity(0.7),
-                        ),
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: colorScheme.onSurface.withOpacity(0.7),
+                            ),
                       ),
                       const SizedBox(height: 8),
                       Container(
@@ -1577,12 +1569,11 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                         ),
                         child: Text(
                           _tour!.location,
-                          style: Theme.of(
-                            context,
-                          ).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.w600,
-                            color: colorScheme.primary,
-                          ),
+                          style: Theme.of(context).textTheme.titleMedium
+                              ?.copyWith(
+                                fontWeight: FontWeight.w600,
+                                color: colorScheme.primary,
+                              ),
                         ),
                       ),
                     ],
@@ -1719,11 +1710,10 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
             )
           else
             Column(
-              children:
-                  _reviews
-                      .take(3)
-                      .map((review) => _buildModernReviewItem(review))
-                      .toList(),
+              children: _reviews
+                  .take(3)
+                  .map((review) => _buildModernReviewItem(review))
+                  .toList(),
             ),
 
           if (_reviews.length > 3) ...[
@@ -1799,10 +1789,9 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                         index < _selectedRating
                             ? Icons.star_rounded
                             : Icons.star_border_rounded,
-                        color:
-                            index < _selectedRating
-                                ? Colors.amber
-                                : colorScheme.outline,
+                        color: index < _selectedRating
+                            ? Colors.amber
+                            : colorScheme.outline,
                         size: 32,
                       ),
                     ),
@@ -1897,21 +1886,19 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                             index < review.rating
                                 ? Icons.star_rounded
                                 : Icons.star_border_rounded,
-                            color:
-                                index < review.rating
-                                    ? Colors.amber
-                                    : colorScheme.outline,
+                            color: index < review.rating
+                                ? Colors.amber
+                                : colorScheme.outline,
                             size: 16,
                           );
                         }),
                         const SizedBox(width: 8),
                         Text(
                           '${review.createdAt.day}/${review.createdAt.month}/${review.createdAt.year}',
-                          style: Theme.of(
-                            context,
-                          ).textTheme.bodySmall?.copyWith(
-                            color: colorScheme.onSurface.withOpacity(0.6),
-                          ),
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(
+                                color: colorScheme.onSurface.withOpacity(0.6),
+                              ),
                         ),
                       ],
                     ),
@@ -2022,11 +2009,12 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                           children: [
                             Text(
                               'Duration',
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodySmall?.copyWith(
-                                color: colorScheme.onSurface.withOpacity(0.6),
-                              ),
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: colorScheme.onSurface.withOpacity(
+                                      0.6,
+                                    ),
+                                  ),
                             ),
                             Text(
                               _tour!.durationText,
@@ -2040,20 +2028,20 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                           children: [
                             Text(
                               'Price per person',
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodySmall?.copyWith(
-                                color: colorScheme.onSurface.withOpacity(0.6),
-                              ),
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: colorScheme.onSurface.withOpacity(
+                                      0.6,
+                                    ),
+                                  ),
                             ),
                             Text(
                               _tour!.displayPrice,
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodyMedium?.copyWith(
-                                color: colorScheme.primary,
-                                fontWeight: FontWeight.bold,
-                              ),
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: colorScheme.primary,
+                                    fontWeight: FontWeight.bold,
+                                  ),
                             ),
                           ],
                         ),
@@ -2079,42 +2067,40 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                         ),
                         const SizedBox(height: 8),
                         InkWell(
-                          onTap:
-                              _isBooking
-                                  ? null
-                                  : () async {
-                                    final date = await showDatePicker(
-                                      context: context,
-                                      initialDate: DateTime.now().add(
-                                        const Duration(days: 1),
-                                      ),
-                                      firstDate: DateTime.now().add(
-                                        const Duration(days: 1),
-                                      ),
-                                      lastDate: DateTime.now().add(
-                                        const Duration(days: 365),
-                                      ),
-                                    );
-                                    if (date != null) {
-                                      setState(() {
-                                        _selectedDate = date;
-                                        _availability = null;
-                                      });
-                                    }
-                                  },
+                          onTap: _isBooking
+                              ? null
+                              : () async {
+                                  final date = await showDatePicker(
+                                    context: context,
+                                    initialDate: DateTime.now().add(
+                                      const Duration(days: 1),
+                                    ),
+                                    firstDate: DateTime.now().add(
+                                      const Duration(days: 1),
+                                    ),
+                                    lastDate: DateTime.now().add(
+                                      const Duration(days: 365),
+                                    ),
+                                  );
+                                  if (date != null) {
+                                    setState(() {
+                                      _selectedDate = date;
+                                      _availability = null;
+                                    });
+                                  }
+                                },
                           child: Container(
                             padding: const EdgeInsets.all(16),
                             decoration: BoxDecoration(
-                              color:
-                                  _selectedDate != null
-                                      ? colorScheme.primaryContainer
-                                          .withOpacity(0.3)
-                                      : colorScheme.surfaceContainerLow,
+                              color: _selectedDate != null
+                                  ? colorScheme.primaryContainer.withOpacity(
+                                      0.3,
+                                    )
+                                  : colorScheme.surfaceContainerLow,
                               border: Border.all(
-                                color:
-                                    _selectedDate != null
-                                        ? colorScheme.primary.withOpacity(0.5)
-                                        : colorScheme.outline.withOpacity(0.3),
+                                color: _selectedDate != null
+                                    ? colorScheme.primary.withOpacity(0.5)
+                                    : colorScheme.outline.withOpacity(0.3),
                               ),
                               borderRadius: BorderRadius.circular(12),
                             ),
@@ -2122,10 +2108,9 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                               children: [
                                 Icon(
                                   Icons.calendar_today_rounded,
-                                  color:
-                                      _selectedDate != null
-                                          ? colorScheme.primary
-                                          : colorScheme.outline,
+                                  color: _selectedDate != null
+                                      ? colorScheme.primary
+                                      : colorScheme.outline,
                                 ),
                                 const SizedBox(width: 8),
                                 Expanded(
@@ -2133,19 +2118,16 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                                     _selectedDate != null
                                         ? '${_selectedDate!.day}/${_selectedDate!.month}/${_selectedDate!.year}'
                                         : 'Choose date...',
-                                    style: Theme.of(
-                                      context,
-                                    ).textTheme.bodyLarge?.copyWith(
-                                      color:
-                                          _selectedDate != null
+                                    style: Theme.of(context).textTheme.bodyLarge
+                                        ?.copyWith(
+                                          color: _selectedDate != null
                                               ? colorScheme.onSurface
                                               : colorScheme.onSurface
-                                                  .withOpacity(0.6),
-                                      fontWeight:
-                                          _selectedDate != null
+                                                    .withOpacity(0.6),
+                                          fontWeight: _selectedDate != null
                                               ? FontWeight.w600
                                               : FontWeight.normal,
-                                    ),
+                                        ),
                                   ),
                                 ),
                               ],
@@ -2179,56 +2161,53 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                           child: Row(
                             children: [
                               IconButton(
-                                onPressed:
-                                    _isBooking || _numberOfPeople <= 1
-                                        ? null
-                                        : () {
-                                          setState(() {
-                                            _numberOfPeople--;
-                                            _availability = null;
-                                          });
-                                          HapticFeedback.lightImpact();
-                                        },
+                                onPressed: _isBooking || _numberOfPeople <= 1
+                                    ? null
+                                    : () {
+                                        setState(() {
+                                          _numberOfPeople--;
+                                          _availability = null;
+                                        });
+                                        HapticFeedback.lightImpact();
+                                      },
                                 icon: Icon(
                                   Icons.remove_rounded,
-                                  color:
-                                      _numberOfPeople > 1
-                                          ? colorScheme.primary
-                                          : colorScheme.outline,
+                                  color: _numberOfPeople > 1
+                                      ? colorScheme.primary
+                                      : colorScheme.outline,
                                 ),
                               ),
                               Expanded(
                                 child: Text(
                                   '$_numberOfPeople',
                                   textAlign: TextAlign.center,
-                                  style: Theme.of(
-                                    context,
-                                  ).textTheme.titleLarge?.copyWith(
-                                    fontWeight: FontWeight.bold,
-                                    color: colorScheme.primary,
-                                  ),
+                                  style: Theme.of(context).textTheme.titleLarge
+                                      ?.copyWith(
+                                        fontWeight: FontWeight.bold,
+                                        color: colorScheme.primary,
+                                      ),
                                 ),
                               ),
                               IconButton(
                                 onPressed:
                                     _isBooking ||
-                                            _numberOfPeople >=
-                                                (_tour?.maxGroupSize ?? 10)
-                                        ? null
-                                        : () {
-                                          setState(() {
-                                            _numberOfPeople++;
-                                            _availability = null;
-                                          });
-                                          HapticFeedback.lightImpact();
-                                        },
+                                        _numberOfPeople >=
+                                            (_tour?.maxGroupSize ?? 10)
+                                    ? null
+                                    : () {
+                                        setState(() {
+                                          _numberOfPeople++;
+                                          _availability = null;
+                                        });
+                                        HapticFeedback.lightImpact();
+                                      },
                                 icon: Icon(
                                   Icons.add_rounded,
                                   color:
                                       _numberOfPeople <
-                                              (_tour?.maxGroupSize ?? 10)
-                                          ? colorScheme.primary
-                                          : colorScheme.outline,
+                                          (_tour?.maxGroupSize ?? 10)
+                                      ? colorScheme.primary
+                                      : colorScheme.outline,
                                 ),
                               ),
                             ],
@@ -2255,18 +2234,16 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                 SizedBox(
                   width: double.infinity,
                   child: OutlinedButton.icon(
-                    onPressed:
-                        _isBooking || _isCheckingAvailability
-                            ? null
-                            : _checkAvailability,
-                    icon:
-                        _isCheckingAvailability
-                            ? const SizedBox(
-                              width: 20,
-                              height: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                            : const Icon(Icons.search_rounded),
+                    onPressed: _isBooking || _isCheckingAvailability
+                        ? null
+                        : _checkAvailability,
+                    icon: _isCheckingAvailability
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.search_rounded),
                     label: Text(
                       _isCheckingAvailability
                           ? 'Checking...'
@@ -2288,10 +2265,9 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                   duration: const Duration(milliseconds: 500),
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
-                    color:
-                        _availability!.isAvailable
-                            ? Colors.green.withOpacity(0.1)
-                            : Colors.red.withOpacity(0.1),
+                    color: _availability!.isAvailable
+                        ? Colors.green.withOpacity(0.1)
+                        : Colors.red.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(12),
                     border: Border.all(
                       color: _availability!.statusColor.withOpacity(0.3),
@@ -2315,12 +2291,11 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                           Expanded(
                             child: Text(
                               _availability!.statusText,
-                              style: Theme.of(
-                                context,
-                              ).textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: _availability!.statusColor,
-                              ),
+                              style: Theme.of(context).textTheme.titleMedium
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: _availability!.statusColor,
+                                  ),
                             ),
                           ),
                         ],
@@ -2336,12 +2311,11 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                             ),
                             Text(
                               _availability!.formattedPrice,
-                              style: Theme.of(
-                                context,
-                              ).textTheme.titleLarge?.copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: colorScheme.primary,
-                              ),
+                              style: Theme.of(context).textTheme.titleLarge
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: colorScheme.primary,
+                                  ),
                             ),
                           ],
                         ),
@@ -2351,11 +2325,12 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                           children: [
                             Text(
                               'Duration:',
-                              style: Theme.of(
-                                context,
-                              ).textTheme.bodyMedium?.copyWith(
-                                color: colorScheme.onSurface.withOpacity(0.7),
-                              ),
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: colorScheme.onSurface.withOpacity(
+                                      0.7,
+                                    ),
+                                  ),
                             ),
                             Text(
                               _availability!.formattedDuration,
@@ -2396,12 +2371,11 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                           ),
                           child: Text(
                             'Optional',
-                            style: Theme.of(
-                              context,
-                            ).textTheme.bodySmall?.copyWith(
-                              color: colorScheme.primary,
-                              fontWeight: FontWeight.w500,
-                            ),
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(
+                                  color: colorScheme.primary,
+                                  fontWeight: FontWeight.w500,
+                                ),
                           ),
                         ),
                       ],
@@ -2459,28 +2433,26 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                   children: [
                     Checkbox(
                       value: _agreedToTerms,
-                      onChanged:
-                          _isBooking
-                              ? null
-                              : (value) {
-                                setState(() {
-                                  _agreedToTerms = value ?? false;
-                                });
-                                HapticFeedback.lightImpact();
-                              },
+                      onChanged: _isBooking
+                          ? null
+                          : (value) {
+                              setState(() {
+                                _agreedToTerms = value ?? false;
+                              });
+                              HapticFeedback.lightImpact();
+                            },
                     ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: GestureDetector(
-                        onTap:
-                            _isBooking
-                                ? null
-                                : () {
-                                  setState(() {
-                                    _agreedToTerms = !_agreedToTerms;
-                                  });
-                                  HapticFeedback.lightImpact();
-                                },
+                        onTap: _isBooking
+                            ? null
+                            : () {
+                                setState(() {
+                                  _agreedToTerms = !_agreedToTerms;
+                                });
+                                HapticFeedback.lightImpact();
+                              },
                         child: Text(
                           'I agree to the terms and conditions and privacy policy',
                           style: Theme.of(
@@ -2501,17 +2473,15 @@ class _TourDetailsScreenState extends State<TourDetailsScreen>
                   child: AnimatedContainer(
                     duration: const Duration(milliseconds: 200),
                     child: CustomButton(
-                      onPressed:
-                          _isBooking || !_agreedToTerms
-                              ? null
-                              : _proceedWithBooking,
+                      onPressed: _isBooking || !_agreedToTerms
+                          ? null
+                          : _proceedWithBooking,
                       isLoading: _isBooking,
                       minimumSize: const Size(double.infinity, 56),
                       borderRadius: 16,
-                      backgroundColor:
-                          _agreedToTerms
-                              ? colorScheme.primary
-                              : colorScheme.outline.withOpacity(0.5),
+                      backgroundColor: _agreedToTerms
+                          ? colorScheme.primary
+                          : colorScheme.outline.withOpacity(0.5),
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
@@ -2743,12 +2713,11 @@ class _BookingSuccessDialogState extends State<BookingSuccessDialog>
                   children: [
                     Text(
                       'Booking Initiated!',
-                      style: Theme.of(
-                        context,
-                      ).textTheme.headlineSmall?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: colorScheme.onSurface,
-                      ),
+                      style: Theme.of(context).textTheme.headlineSmall
+                          ?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: colorScheme.onSurface,
+                          ),
                     ),
                     const SizedBox(height: 8),
                     Text(
@@ -2778,12 +2747,11 @@ class CheckPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     if (animationValue == 0) return;
 
-    final paint =
-        Paint()
-          ..color = Colors.white
-          ..strokeWidth = 4
-          ..style = PaintingStyle.stroke
-          ..strokeCap = StrokeCap.round;
+    final paint = Paint()
+      ..color = Colors.white
+      ..strokeWidth = 4
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
 
     final center = Offset(size.width / 2, size.height / 2);
 

--- a/lib/widgets/responsive_tour_card.dart
+++ b/lib/widgets/responsive_tour_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../models/tour_models.dart';
 import '../screens/tours/tour_details_screen.dart';
+import './seamless_page_route.dart';
 
 class ResponsiveTourCard extends StatefulWidget {
   final Tour tour;
@@ -60,10 +61,9 @@ class _ResponsiveTourCardState extends State<ResponsiveTourCard>
 
   void _navigateToDetails() {
     HapticFeedback.lightImpact();
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => TourDetailsScreen(tourId: widget.tour.id),
-      ),
+    showSeamlessPage(
+      context,
+      (context) => TourDetailsScreen(tourId: widget.tour.id),
     );
   }
 
@@ -117,39 +117,36 @@ class _ResponsiveTourCardState extends State<ResponsiveTourCard>
             ),
             child:
                 widget.tour.mainImageUrl != null &&
-                        widget.tour.mainImageUrl!.isNotEmpty
-                    ? ClipRRect(
-                      borderRadius: const BorderRadius.only(
-                        topLeft: Radius.circular(12),
-                        topRight: Radius.circular(12),
+                    widget.tour.mainImageUrl!.isNotEmpty
+                ? ClipRRect(
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(12),
+                      topRight: Radius.circular(12),
+                    ),
+                    child: Hero(
+                      tag: 'tour_${widget.tour.id}',
+                      child: Image.network(
+                        widget.tour.mainImageUrl!,
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, error, stackTrace) =>
+                            _buildImagePlaceholder(),
+                        loadingBuilder: (context, child, loadingProgress) {
+                          if (loadingProgress == null) return child;
+                          return Center(
+                            child: CircularProgressIndicator(
+                              value: loadingProgress.expectedTotalBytes != null
+                                  ? loadingProgress.cumulativeBytesLoaded /
+                                        loadingProgress.expectedTotalBytes!
+                                  : null,
+                              strokeWidth: 2,
+                              color: colorScheme.primary,
+                            ),
+                          );
+                        },
                       ),
-                      child: Hero(
-                        tag: 'tour_${widget.tour.id}',
-                        child: Image.network(
-                          widget.tour.mainImageUrl!,
-                          fit: BoxFit.cover,
-                          errorBuilder:
-                              (context, error, stackTrace) =>
-                                  _buildImagePlaceholder(),
-                          loadingBuilder: (context, child, loadingProgress) {
-                            if (loadingProgress == null) return child;
-                            return Center(
-                              child: CircularProgressIndicator(
-                                value:
-                                    loadingProgress.expectedTotalBytes != null
-                                        ? loadingProgress
-                                                .cumulativeBytesLoaded /
-                                            loadingProgress.expectedTotalBytes!
-                                        : null,
-                                strokeWidth: 2,
-                                color: colorScheme.primary,
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                    )
-                    : _buildImagePlaceholder(),
+                    ),
+                  )
+                : _buildImagePlaceholder(),
           ),
         ),
 

--- a/lib/widgets/seamless_page_route.dart
+++ b/lib/widgets/seamless_page_route.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+Future<T?> showSeamlessPage<T>(BuildContext context, WidgetBuilder builder) {
+  return Navigator.of(context).push(_SeamlessPageRoute<T>(builder));
+}
+
+class _SeamlessPageRoute<T> extends PageRouteBuilder<T> {
+  _SeamlessPageRoute(this.builder)
+    : super(
+        pageBuilder: (context, animation, secondaryAnimation) =>
+            builder(context),
+        opaque: false,
+        barrierColor: Colors.black54,
+        barrierDismissible: true,
+        transitionDuration: const Duration(milliseconds: 300),
+        reverseTransitionDuration: const Duration(milliseconds: 300),
+        transitionsBuilder: (context, animation, secondaryAnimation, child) {
+          final curved = CurvedAnimation(
+            parent: animation,
+            curve: Curves.easeOut,
+          );
+          return FadeTransition(
+            opacity: curved,
+            child: SlideTransition(
+              position: Tween<Offset>(
+                begin: const Offset(0, 0.1),
+                end: Offset.zero,
+              ).animate(curved),
+              child: child,
+            ),
+          );
+        },
+      );
+
+  final WidgetBuilder builder;
+}


### PR DESCRIPTION
## Summary
- add a generic seamless page route for dialog-like detail pages
- open tour and car details with `showSeamlessPage`
- decrease animation durations in detail screens for snappier feel

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6844b92b0068832491b3da4a4c84c8ef