### PR TITLE
Add AppLayout wrapper

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'screens/recommendation/recommendation_screen.dart';
 import 'services/auth_service.dart';
 import 'services/stripe_service.dart';
 import 'widgets/resizable_navigation_rail.dart';
+import 'widgets/app_layout.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -38,6 +39,7 @@ class MyApp extends StatelessWidget {
       theme: _buildLightTheme(),
       darkTheme: _buildDarkTheme(),
       themeMode: ThemeMode.system,
+      builder: (context, child) => AppLayout(child: child ?? const SizedBox()),
       home: const AuthWrapper(),
       routes: {
         '/login': (context) => const LoginScreen(),
@@ -473,76 +475,68 @@ class _HomeScreenState extends State<HomeScreen> {
     ];
 
     return Scaffold(
-      body:
-          isDesktop
-              ? Row(
-                children: [
-                  ResizableNavigationRail(
-                    selectedIndex: _currentIndex,
-                    onDestinationSelected: (index) {
-                      if (index != _currentIndex) {
-                        setState(() => _currentIndex = index);
-                        HapticFeedback.selectionClick();
-                      }
-                    },
-                    backgroundColor: colorScheme.surface,
-                    selectedIconTheme: IconThemeData(
-                      color: colorScheme.primary,
-                    ),
-                    indicatorColor: colorScheme.primary.withOpacity(0.1),
-                    destinations:
-                        navigationDestinations
-                            .map(
-                              (e) => NavigationRailDestination(
-                                icon: e.icon,
-                                selectedIcon: e.selectedIcon!,
-                                label: Text(e.label),
-                              ),
-                            )
-                            .toList(),
-                  ),
-                  const VerticalDivider(width: 1),
-                  Expanded(
-                    child: IndexedStack(
-                      index: _currentIndex,
-                      children: screens,
-                    ),
+      body: isDesktop
+          ? Row(
+              children: [
+                ResizableNavigationRail(
+                  selectedIndex: _currentIndex,
+                  onDestinationSelected: (index) {
+                    if (index != _currentIndex) {
+                      setState(() => _currentIndex = index);
+                      HapticFeedback.selectionClick();
+                    }
+                  },
+                  backgroundColor: colorScheme.surface,
+                  selectedIconTheme: IconThemeData(color: colorScheme.primary),
+                  indicatorColor: colorScheme.primary.withOpacity(0.1),
+                  destinations: navigationDestinations
+                      .map(
+                        (e) => NavigationRailDestination(
+                          icon: e.icon,
+                          selectedIcon: e.selectedIcon!,
+                          label: Text(e.label),
+                        ),
+                      )
+                      .toList(),
+                ),
+                const VerticalDivider(width: 1),
+                Expanded(
+                  child: IndexedStack(index: _currentIndex, children: screens),
+                ),
+              ],
+            )
+          : IndexedStack(index: _currentIndex, children: screens),
+      bottomNavigationBar: isDesktop
+          ? null
+          : Container(
+              decoration: BoxDecoration(
+                color: colorScheme.surface,
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.1),
+                    blurRadius: 8,
+                    offset: const Offset(0, -2),
                   ),
                 ],
-              )
-              : IndexedStack(index: _currentIndex, children: screens),
-      bottomNavigationBar:
-          isDesktop
-              ? null
-              : Container(
-                decoration: BoxDecoration(
-                  color: colorScheme.surface,
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
-                      blurRadius: 8,
-                      offset: const Offset(0, -2),
-                    ),
-                  ],
-                ),
-                child: SafeArea(
-                  child: NavigationBar(
-                    selectedIndex: _currentIndex,
-                    onDestinationSelected: (index) {
-                      if (index != _currentIndex) {
-                        setState(() {
-                          _currentIndex = index;
-                        });
-                        HapticFeedback.selectionClick();
-                      }
-                    },
-                    backgroundColor: colorScheme.surface,
-                    surfaceTintColor: colorScheme.surface,
-                    indicatorColor: colorScheme.primary.withOpacity(0.1),
-                    destinations: navigationDestinations,
-                  ),
+              ),
+              child: SafeArea(
+                child: NavigationBar(
+                  selectedIndex: _currentIndex,
+                  onDestinationSelected: (index) {
+                    if (index != _currentIndex) {
+                      setState(() {
+                        _currentIndex = index;
+                      });
+                      HapticFeedback.selectionClick();
+                    }
+                  },
+                  backgroundColor: colorScheme.surface,
+                  surfaceTintColor: colorScheme.surface,
+                  indicatorColor: colorScheme.primary.withOpacity(0.1),
+                  destinations: navigationDestinations,
                 ),
               ),
+            ),
     );
   }
 }

--- a/lib/widgets/app_layout.dart
+++ b/lib/widgets/app_layout.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+/// A basic layout that wraps every screen with a standard [Scaffold].
+/// If the child already provides its own [Scaffold], it will be returned
+/// directly so that existing pages are unaffected.
+class AppLayout extends StatelessWidget {
+  final Widget child;
+  final PreferredSizeWidget? appBar;
+
+  const AppLayout({Key? key, required this.child, this.appBar})
+    : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (child is Scaffold) {
+      return child;
+    }
+
+    return Scaffold(
+      appBar: appBar ?? AppBar(title: const Text('TourApp')),
+      body: child,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `AppLayout` widget to wrap screens in a unified scaffold
- apply `AppLayout` globally via `MaterialApp.builder`

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6844c072cc5c8324bf8aabf81c2f7ed8