### PR TITLE
Add modern web-style landing page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:tour_flutter_main/models/auth_models.dart';
 import 'screens/auth/login_screen.dart';
 import 'screens/auth/register_screen.dart';
 import 'screens/tours/tour_list_screen.dart';
+import 'screens/home/home_web_screen.dart';
 import 'screens/cars/car_list_screen.dart';
 import 'screens/admin/admin_tour_create_screen.dart';
 import 'screens/admin/admin_panel_screen.dart';
@@ -44,6 +45,7 @@ class MyApp extends StatelessWidget {
       routes: {
         '/login': (context) => const LoginScreen(),
         '/register': (context) => const RegisterScreen(),
+        '/home': (context) => const HomeWebScreen(),
         '/tours': (context) => const TourListScreen(),
         '/cars': (context) => const CarListScreen(),
         '/admin-panel': (context) => const AdminPanelScreen(),
@@ -210,6 +212,7 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _isAdmin = false;
 
   final List<Widget> _userScreens = [
+    const HomeWebScreen(),
     const TourListScreen(),
     const RecommendationScreen(),
     const CarListScreen(),
@@ -218,6 +221,7 @@ class _HomeScreenState extends State<HomeScreen> {
   ];
 
   final List<Widget> _adminScreens = [
+    const HomeWebScreen(),
     const TourListScreen(),
     const RecommendationScreen(),
     const CarListScreen(),
@@ -248,6 +252,11 @@ class _HomeScreenState extends State<HomeScreen> {
     final bool isDesktop = MediaQuery.of(context).size.width >= 800;
 
     final navigationDestinations = <NavigationDestination>[
+      NavigationDestination(
+        icon: const Icon(Icons.home_outlined),
+        selectedIcon: Icon(Icons.home, color: colorScheme.primary),
+        label: 'Home',
+      ),
       NavigationDestination(
         icon: const Icon(Icons.explore_outlined),
         selectedIcon: Icon(Icons.explore, color: colorScheme.primary),

--- a/lib/screens/home/home_web_screen.dart
+++ b/lib/screens/home/home_web_screen.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import '../../widgets/modern_widgets.dart';
+
+/// A simple landing page styled like a modern website.
+class HomeWebScreen extends StatelessWidget {
+  const HomeWebScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isDesktop = MediaQuery.of(context).size.width >= 800;
+    final heroHeight = isDesktop ? 500.0 : 300.0;
+
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SizedBox(
+              height: heroHeight,
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  Positioned.fill(
+                    child: Image.network(
+                      'https://images.unsplash.com/photo-1507525428034-b723cf961d3e',
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                  Container(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                        colors: [
+                          Colors.black.withOpacity(0.4),
+                          Colors.black.withOpacity(0.2),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          'Explore the World',
+                          style: Theme.of(context).textTheme.headlineLarge
+                              ?.copyWith(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                              ),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          'Find unforgettable experiences and make memories.',
+                          style: Theme.of(context).textTheme.bodyLarge
+                              ?.copyWith(color: Colors.white70),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 24),
+                        FilledButton(
+                          onPressed: () {
+                            Navigator.of(context).pushNamed('/tours');
+                          },
+                          child: const Text('Start Exploring'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'Why Choose TourApp?',
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: colorScheme.primary,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  Wrap(
+                    alignment: WrapAlignment.center,
+                    spacing: 24,
+                    runSpacing: 24,
+                    children: const [
+                      _FeatureCard(
+                        icon: Icons.public,
+                        title: 'Worldwide Tours',
+                        description:
+                            'Discover amazing places across the globe.',
+                      ),
+                      _FeatureCard(
+                        icon: Icons.star_outline,
+                        title: 'Top Rated Guides',
+                        description: 'Travel with experienced local guides.',
+                      ),
+                      _FeatureCard(
+                        icon: Icons.payment,
+                        title: 'Secure Payments',
+                        description: 'Pay confidently with secure checkout.',
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FeatureCard extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String description;
+
+  const _FeatureCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return SizedBox(
+      width: 260,
+      child: ModernCard(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Icon(icon, size: 48, color: colorScheme.primary),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              description,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurface.withOpacity(0.7),
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -3,6 +3,7 @@ export 'auth/login_screen.dart';
 export 'auth/register_screen.dart';
 export 'tours/tour_list_screen.dart';
 export 'tours/tour_details_screen.dart';
+export 'home/home_web_screen.dart';
 export 'booking/booking_screen.dart';
 export 'booking/payment_screen.dart';
 export 'booking/payment_result_screen.dart';


### PR DESCRIPTION
## Summary
- create `HomeWebScreen` landing page with hero section and features
- export the landing page
- show `HomeWebScreen` in navigation with new route

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6845588a41508324a84339c928771e47