### PR TITLE
Add photo inspiration section

### DIFF
--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,3 +1,4 @@
 // Export all models
+export 'photo_models.dart';
 export 'auth_models.dart';
 export 'tour_models.dart';

--- a/lib/models/photo_models.dart
+++ b/lib/models/photo_models.dart
@@ -1,0 +1,22 @@
+class InspirationPhoto {
+  final String id;
+  final String author;
+  final String url;
+  final String downloadUrl;
+
+  InspirationPhoto({
+    required this.id,
+    required this.author,
+    required this.url,
+    required this.downloadUrl,
+  });
+
+  factory InspirationPhoto.fromJson(Map<String, dynamic> json) {
+    return InspirationPhoto(
+      id: json['id'].toString(),
+      author: json['author'] ?? 'Unknown',
+      url: json['url'] ?? '',
+      downloadUrl: json['download_url'] ?? '',
+    );
+  }
+}

--- a/lib/screens/home/home_web_screen.dart
+++ b/lib/screens/home/home_web_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'widgets/hero_section.dart';
 import 'widgets/features_section.dart';
+import 'widgets/inspiration_section.dart';
 
 /// A simple landing page styled like a modern website.
 class HomeWebScreen extends StatelessWidget {
@@ -16,10 +17,10 @@ class HomeWebScreen extends StatelessWidget {
         foregroundColor: Colors.white,
         title: Text(
           'TourApp',
-          style: Theme.of(context)
-              .textTheme
-              .titleLarge
-              ?.copyWith(fontWeight: FontWeight.bold, color: Colors.white),
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
         ),
         actions: [
           TextButton(
@@ -39,6 +40,7 @@ class HomeWebScreen extends StatelessWidget {
         slivers: [
           SliverToBoxAdapter(child: HomeHeroSection()),
           SliverToBoxAdapter(child: HomeFeaturesSection()),
+          SliverToBoxAdapter(child: HomeInspirationSection()),
           SliverToBoxAdapter(child: SizedBox(height: 40)),
         ],
       ),

--- a/lib/screens/home/widgets/inspiration_section.dart
+++ b/lib/screens/home/widgets/inspiration_section.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import '../../../models/photo_models.dart';
+import '../../../services/photo_service.dart';
+import '../../../widgets/modern_widgets.dart';
+
+class HomeInspirationSection extends StatefulWidget {
+  const HomeInspirationSection({super.key});
+
+  @override
+  State<HomeInspirationSection> createState() => _HomeInspirationSectionState();
+}
+
+class _HomeInspirationSectionState extends State<HomeInspirationSection> {
+  final PhotoService _photoService = PhotoService();
+  late Future<List<InspirationPhoto>> _photosFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _photosFuture = _photoService.fetchInspirationPhotos(limit: 5);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 48, horizontal: 24),
+      child: FutureBuilder<List<InspirationPhoto>>(
+        future: _photosFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const SizedBox(
+              height: 260,
+              child: Center(child: CircularProgressIndicator()),
+            );
+          } else if (snapshot.hasError) {
+            return ModernErrorState(
+              title: 'Oops',
+              message: 'Failed to load inspiration.',
+              actionText: 'Retry',
+              onRetry: () => setState(() {
+                _photosFuture = _photoService.fetchInspirationPhotos(limit: 5);
+              }),
+            );
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const SizedBox.shrink();
+          }
+
+          final photos = snapshot.data!;
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Get Inspired',
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.primary,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                height: 250,
+                child: PageView.builder(
+                  controller: PageController(viewportFraction: 0.8),
+                  itemCount: photos.length,
+                  itemBuilder: (context, index) {
+                    final photo = photos[index];
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(20),
+                        child: Stack(
+                          fit: StackFit.expand,
+                          children: [
+                            Image.network(photo.downloadUrl, fit: BoxFit.cover),
+                            Positioned(
+                              bottom: 0,
+                              left: 0,
+                              right: 0,
+                              child: Container(
+                                color: Colors.black45,
+                                padding: const EdgeInsets.all(8),
+                                child: Text(
+                                  photo.author,
+                                  style: const TextStyle(color: Colors.white),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/photo_service.dart
+++ b/lib/services/photo_service.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/photo_models.dart';
+
+class PhotoService {
+  static const String _baseUrl = 'https://picsum.photos/v2';
+
+  Future<List<InspirationPhoto>> fetchInspirationPhotos({int limit = 5}) async {
+    final uri = Uri.parse('$_baseUrl/list?limit=$limit');
+    final response = await http.get(uri);
+    if (response.statusCode == 200) {
+      final List<dynamic> data = json.decode(response.body) as List<dynamic>;
+      return data
+          .map(
+            (item) => InspirationPhoto.fromJson(item as Map<String, dynamic>),
+          )
+          .toList();
+    } else {
+      throw Exception('Failed to load inspiration photos');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- export `photo_models.dart`
- model `InspirationPhoto`
- service `PhotoService` to fetch images from picsum.photos
- widget `HomeInspirationSection` shows a carousel of photos
- include new section in `HomeWebScreen`

## Testing
- `flutter analyze` *(fails: 673 issues)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6846065089e08324a0f457e63d01d5fd