### PR TITLE
Improve mobile home UI

### DIFF
--- a/lib/screens/favorites/favorites_screen.dart
+++ b/lib/screens/favorites/favorites_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// Simple placeholder screen for saved items.
+class FavoritesScreen extends StatelessWidget {
+  const FavoritesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Favorites')),
+      body: const Center(
+        child: Text('No favorites yet', style: TextStyle(fontSize: 18)),
+      ),
+    );
+  }
+}

--- a/lib/screens/home/home_mobile_screen.dart
+++ b/lib/screens/home/home_mobile_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import '../cars/car_list_screen.dart';
+import '../tours/tour_list_screen.dart';
+
+/// Mobile optimized home screen with tabs for tours and cars.
+class HomeMobileScreen extends StatelessWidget {
+  const HomeMobileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('TourApp'),
+          bottom: const TabBar(tabs: [Tab(text: 'Tours'), Tab(text: 'Cars')]),
+        ),
+        body: const TabBarView(children: [TourListScreen(), CarListScreen()]),
+      ),
+    );
+  }
+}

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -8,6 +8,8 @@ import '../admin/admin_tour_create_screen.dart';
 import '../profile/profile_screen.dart';
 import '../booking/booking_screen.dart';
 import '../home/home_web_screen.dart';
+import '../home/home_mobile_screen.dart';
+import '../favorites/favorites_screen.dart';
 import '../recommendation/recommendation_screen.dart';
 import '../../widgets/resizable_navigation_rail.dart';
 
@@ -42,6 +44,12 @@ class _HomeScreenState extends State<HomeScreen> {
     const ProfileScreen(),
   ];
 
+  final List<Widget> _mobileScreens = [
+    const HomeMobileScreen(),
+    const FavoritesScreen(),
+    const ProfileScreen(),
+  ];
+
   @override
   void initState() {
     super.initState();
@@ -59,115 +67,146 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final screens = _isAdmin ? _adminScreens : _userScreens;
-    final colorScheme = Theme.of(context).colorScheme;
     final bool isDesktop = MediaQuery.of(context).size.width >= 800;
+    final screens =
+        isDesktop ? (_isAdmin ? _adminScreens : _userScreens) : _mobileScreens;
+    final colorScheme = Theme.of(context).colorScheme;
 
-    final navigationDestinations = <NavigationDestination>[
-      NavigationDestination(
-        icon: const Icon(Icons.home_outlined),
-        selectedIcon: Icon(Icons.home, color: colorScheme.primary),
-        label: 'Home',
-      ),
-      NavigationDestination(
-        icon: const Icon(Icons.explore_outlined),
-        selectedIcon: Icon(Icons.explore, color: colorScheme.primary),
-        label: 'Discover',
-      ),
-      NavigationDestination(
-        icon: const Icon(Icons.recommend_outlined),
-        selectedIcon: Icon(Icons.recommend, color: colorScheme.primary),
-        label: 'For You',
-      ),
-      NavigationDestination(
-        icon: const Icon(Icons.directions_car_outlined),
-        selectedIcon: Icon(Icons.directions_car, color: colorScheme.primary),
-        label: 'Cars',
-      ),
-      NavigationDestination(
-        icon: const Icon(Icons.bookmark_border_outlined),
-        selectedIcon: Icon(Icons.bookmark, color: colorScheme.primary),
-        label: 'Bookings',
-      ),
-      if (_isAdmin)
-        NavigationDestination(
-          icon: const Icon(Icons.admin_panel_settings_outlined),
-          selectedIcon: Icon(
-            Icons.admin_panel_settings,
-            color: colorScheme.primary,
-          ),
-          label: 'Admin',
-        ),
-      NavigationDestination(
-        icon: const Icon(Icons.person_outline),
-        selectedIcon: Icon(Icons.person, color: colorScheme.primary),
-        label: 'Profile',
-      ),
-    ];
+    final navigationDestinations =
+        isDesktop
+            ? <NavigationDestination>[
+              NavigationDestination(
+                icon: const Icon(Icons.home_outlined),
+                selectedIcon: Icon(Icons.home, color: colorScheme.primary),
+                label: 'Home',
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.explore_outlined),
+                selectedIcon: Icon(Icons.explore, color: colorScheme.primary),
+                label: 'Discover',
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.recommend_outlined),
+                selectedIcon: Icon(Icons.recommend, color: colorScheme.primary),
+                label: 'For You',
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.directions_car_outlined),
+                selectedIcon: Icon(
+                  Icons.directions_car,
+                  color: colorScheme.primary,
+                ),
+                label: 'Cars',
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.bookmark_border_outlined),
+                selectedIcon: Icon(Icons.bookmark, color: colorScheme.primary),
+                label: 'Bookings',
+              ),
+              if (_isAdmin)
+                NavigationDestination(
+                  icon: const Icon(Icons.admin_panel_settings_outlined),
+                  selectedIcon: Icon(
+                    Icons.admin_panel_settings,
+                    color: colorScheme.primary,
+                  ),
+                  label: 'Admin',
+                ),
+              NavigationDestination(
+                icon: const Icon(Icons.person_outline),
+                selectedIcon: Icon(Icons.person, color: colorScheme.primary),
+                label: 'Profile',
+              ),
+            ]
+            : <NavigationDestination>[
+              NavigationDestination(
+                icon: const Icon(Icons.home_outlined),
+                selectedIcon: Icon(Icons.home, color: colorScheme.primary),
+                label: 'Home',
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.favorite_outline),
+                selectedIcon: Icon(Icons.favorite, color: colorScheme.primary),
+                label: 'Favorites',
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.person_outline),
+                selectedIcon: Icon(Icons.person, color: colorScheme.primary),
+                label: 'Profile',
+              ),
+            ];
 
     return Scaffold(
-      body: isDesktop
-          ? Row(
-              children: [
-                ResizableNavigationRail(
-                  selectedIndex: _currentIndex,
-                  onDestinationSelected: (index) {
-                    if (index != _currentIndex) {
-                      setState(() => _currentIndex = index);
-                      HapticFeedback.selectionClick();
-                    }
-                  },
-                  backgroundColor: colorScheme.surface,
-                  selectedIconTheme: IconThemeData(color: colorScheme.primary),
-                  indicatorColor: colorScheme.primary.withOpacity(0.1),
-                  destinations: navigationDestinations
-                      .map(
-                        (e) => NavigationRailDestination(
-                          icon: e.icon,
-                          selectedIcon: e.selectedIcon!,
-                          label: Text(e.label),
-                        ),
-                      )
-                      .toList(),
-                ),
-                const VerticalDivider(width: 1),
-                Expanded(
-                  child: IndexedStack(index: _currentIndex, children: screens),
-                ),
-              ],
-            )
-          : IndexedStack(index: _currentIndex, children: screens),
-      bottomNavigationBar: isDesktop
-          ? null
-          : Container(
-              decoration: BoxDecoration(
-                color: colorScheme.surface,
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.1),
-                    blurRadius: 8,
-                    offset: const Offset(0, -2),
+      body:
+          isDesktop
+              ? Row(
+                children: [
+                  ResizableNavigationRail(
+                    selectedIndex: _currentIndex,
+                    onDestinationSelected: (index) {
+                      if (index != _currentIndex) {
+                        setState(() => _currentIndex = index);
+                        HapticFeedback.selectionClick();
+                      }
+                    },
+                    backgroundColor: colorScheme.surface,
+                    selectedIconTheme: IconThemeData(
+                      color: colorScheme.primary,
+                    ),
+                    indicatorColor: colorScheme.primary.withOpacity(0.1),
+                    destinations:
+                        navigationDestinations
+                            .map(
+                              (e) => NavigationRailDestination(
+                                icon: e.icon,
+                                selectedIcon: e.selectedIcon!,
+                                label: Text(e.label),
+                              ),
+                            )
+                            .toList(),
+                  ),
+                  const VerticalDivider(width: 1),
+                  Expanded(
+                    child: IndexedStack(
+                      index: _currentIndex,
+                      children: screens,
+                    ),
                   ),
                 ],
-              ),
-              child: SafeArea(
-                child: NavigationBar(
-                  selectedIndex: _currentIndex,
-                  onDestinationSelected: (index) {
-                    if (index != _currentIndex) {
-                      setState(() {
-                        _currentIndex = index;
-                      });
-                      HapticFeedback.selectionClick();
-                    }
-                  },
-                  backgroundColor: colorScheme.surface,
-                  surfaceTintColor: colorScheme.surface,
-                  indicatorColor: colorScheme.primary.withOpacity(0.1),
-                  destinations: navigationDestinations,
+              )
+              : IndexedStack(index: _currentIndex, children: screens),
+      bottomNavigationBar:
+          isDesktop
+              ? null
+              : Container(
+                decoration: BoxDecoration(
+                  color: colorScheme.surface,
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.1),
+                      blurRadius: 8,
+                      offset: const Offset(0, -2),
+                    ),
+                  ],
+                ),
+                child: SafeArea(
+                  child: NavigationBar(
+                    selectedIndex: _currentIndex,
+                    onDestinationSelected: (index) {
+                      if (index != _currentIndex) {
+                        setState(() {
+                          _currentIndex = index;
+                        });
+                        HapticFeedback.selectionClick();
+                      }
+                    },
+                    backgroundColor: colorScheme.surface,
+                    surfaceTintColor: colorScheme.surface,
+                    indicatorColor: colorScheme.primary.withOpacity(0.1),
+                    destinations: navigationDestinations,
+                  ),
                 ),
               ),
-            ),
     );
   }
 }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -5,9 +5,9 @@ import 'package:google_fonts/google_fonts.dart';
 class AppTheme {
   /// Light [ThemeData] inspired by modern web aesthetics.
   static ThemeData light() {
-    const primaryColor = Color(0xFF0D6EFD); // Bootstrap blue
-    const secondaryColor = Color(0xFF6610F2); // Accent purple
-    const accentColor = Color(0xFF198754); // Success green
+    const primaryColor = Color(0xFF003B95); // Booking.com blue
+    const secondaryColor = Color(0xFFFFB700); // Accent yellow
+    const accentColor = Color(0xFF00A698); // Complimentary teal
     const backgroundColor = Color(0xFFF8F9FA);
     const surfaceColor = Color(0xFFFFFFFF);
     const cardColor = Color(0xFFFFFFFF);
@@ -100,9 +100,9 @@ class AppTheme {
 
   /// Dark [ThemeData] providing a complementary palette.
   static ThemeData dark() {
-    const primaryColor = Color(0xFF0D6EFD); // Same base blue
-    const secondaryColor = Color(0xFF7C4DFF);
-    const accentColor = Color(0xFF20C997);
+    const primaryColor = Color(0xFF003B95); // Same base blue
+    const secondaryColor = Color(0xFFFFB700);
+    const accentColor = Color(0xFF00A698);
     const backgroundColor = Color(0xFF121212);
     const surfaceColor = Color(0xFF1E1E1E);
     const cardColor = Color(0xFF2C2C2C);


### PR DESCRIPTION
## Summary
- refresh AppTheme colors for a modern blue and yellow palette
- add a simplified mobile home page with tabs for tours and cars
- add placeholder Favorites screen
- update HomeScreen to use new mobile layout and bottom navigation

## Testing
- `flutter analyze` *(fails: 13506 issues)*
- `flutter test` *(fails: Compilation failed for payment_screen.dart)*

------
https://chatgpt.com/codex/tasks/task_e_68826e7b3e6c8324a22620e24b4d2699