### PR TITLE
Improve landing screen layouts

### DIFF
--- a/lib/screens/home/home_mobile_screen.dart
+++ b/lib/screens/home/home_mobile_screen.dart
@@ -1,35 +1,25 @@
 import 'package:flutter/material.dart';
-import '../cars/car_list_screen.dart';
-import '../houses/house_list_screen.dart';
-import '../tours/tour_list_screen.dart';
+import 'widgets/hero_section.dart';
+import 'widgets/features_section.dart';
+import 'widgets/inspiration_section.dart';
+import 'widgets/quick_access_section.dart';
+import 'widgets/footer.dart';
 
-/// Mobile optimized home screen with tabs for tours, houses and cars.
+/// Mobile friendly landing screen using a scrolling layout.
 class HomeMobileScreen extends StatelessWidget {
   const HomeMobileScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return DefaultTabController(
-      length: 3,
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('TourApp'),
-          bottom: const TabBar(
-            isScrollable: true,
-            tabs: [
-              Tab(text: 'Tours'),
-              Tab(text: 'Houses'),
-              Tab(text: 'Cars'),
-            ],
-          ),
-        ),
-        body: const TabBarView(
-          children: [
-            TourListScreen(),
-            HouseListScreen(),
-            CarListScreen(),
-          ],
-        ),
+    return const Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          SliverToBoxAdapter(child: HomeHeroSection()),
+          SliverToBoxAdapter(child: HomeQuickAccessSection()),
+          SliverToBoxAdapter(child: HomeFeaturesSection()),
+          SliverToBoxAdapter(child: HomeInspirationSection()),
+          SliverToBoxAdapter(child: HomeFooter()),
+        ],
       ),
     );
   }

--- a/lib/screens/home/home_web_screen.dart
+++ b/lib/screens/home/home_web_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'widgets/hero_section.dart';
 import 'widgets/features_section.dart';
 import 'widgets/inspiration_section.dart';
+import 'widgets/quick_access_section.dart';
+import 'widgets/footer.dart';
 
 /// A simple landing page styled like a modern website.
 class HomeWebScreen extends StatelessWidget {
@@ -39,9 +41,10 @@ class HomeWebScreen extends StatelessWidget {
       body: const CustomScrollView(
         slivers: [
           SliverToBoxAdapter(child: HomeHeroSection()),
+          SliverToBoxAdapter(child: HomeQuickAccessSection()),
           SliverToBoxAdapter(child: HomeFeaturesSection()),
           SliverToBoxAdapter(child: HomeInspirationSection()),
-          SliverToBoxAdapter(child: SizedBox(height: 40)),
+          SliverToBoxAdapter(child: HomeFooter()),
         ],
       ),
     );

--- a/lib/screens/home/widgets/footer.dart
+++ b/lib/screens/home/widgets/footer.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+/// Simple footer used on the home screens.
+class HomeFooter extends StatelessWidget {
+  const HomeFooter({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+      alignment: Alignment.center,
+      child: Text(
+        '© 2024 TourApp. All rights reserved.',
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurface.withOpacity(0.6),
+            ),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}

--- a/lib/screens/home/widgets/quick_access_section.dart
+++ b/lib/screens/home/widgets/quick_access_section.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+/// Section with quick links to key parts of the app.
+class HomeQuickAccessSection extends StatelessWidget {
+  const HomeQuickAccessSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 24),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          _QuickAccessButton(
+            icon: Icons.tour,
+            label: 'Tours',
+            onTap: () => Navigator.pushNamed(context, '/tours'),
+            color: colorScheme.primary,
+          ),
+          _QuickAccessButton(
+            icon: Icons.house,
+            label: 'Houses',
+            onTap: () => Navigator.pushNamed(context, '/houses'),
+            color: colorScheme.tertiary,
+          ),
+          _QuickAccessButton(
+            icon: Icons.directions_car,
+            label: 'Cars',
+            onTap: () => Navigator.pushNamed(context, '/cars'),
+            color: colorScheme.secondary,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _QuickAccessButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final Color color;
+
+  const _QuickAccessButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: color.withOpacity(0.1),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(icon, color: color, size: 28),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- redesign mobile home screen using scrolling layout
- add quick access and footer widgets
- integrate new sections into desktop home screen

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*
- `apt-get install -y dart` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_68827762bda08324a8cefcde64a03979